### PR TITLE
Add the bootstrap stack

### DIFF
--- a/terraform/modules/bootstrap_concourse/assets/pipeline.yml
+++ b/terraform/modules/bootstrap_concourse/assets/pipeline.yml
@@ -25,5 +25,5 @@
   - name: pipeline-tasks
     type: git
     source:
-      uri: https://github.com/cnelson/cg-pipeline-tasks
+      uri: https://github.com/18F/cg-pipeline-tasks
       branch: master

--- a/terraform/modules/bootstrap_concourse/assets/pipeline.yml
+++ b/terraform/modules/bootstrap_concourse/assets/pipeline.yml
@@ -1,0 +1,29 @@
+  # This file must be indented at least two spaces, so that when it's
+  # included in the terraform configuration, the indentation is correct
+  jobs:
+  - name: bootstrap
+    plan:
+    - get: cg-provision
+      trigger: true
+    - get: pipeline-tasks
+    - task: apply-test-stack
+      file: pipeline-tasks/terraform-apply.yml
+      input_mapping:
+        terraform-templates: cg-provision
+      params:
+        STACK_NAME: test
+        AWS_DEFAULT_REGION: ${aws_default_region}
+        S3_TFSTATE_BUCKET: terraform-state
+        TEMPLATE_SUBDIR: terraform/stacks/test
+
+  resources:
+  - name: cg-provision
+    type: git
+    source:
+      uri: https://github.com/18F/cg-provision
+      branch: cn-modules
+  - name: pipeline-tasks
+    type: git
+    source:
+      uri: https://github.com/cnelson/cg-pipeline-tasks
+      branch: master

--- a/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role" "bootstrap" {
+  name = "boostrap"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+     "Action": "sts:AssumeRole",
+      "Principal": {"Service": "ec2.amazonaws.com"},
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "bootstrap" {
+  name = "bootstrap"
+  roles = ["${aws_iam_role.bootstrap.name}"]
+}
+
+resource "aws_iam_role_policy" "bootstrap" {
+  name = "bootstrap"
+  role = "${aws_iam_role.bootstrap.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1464140990363",
+      "Action": "*",
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/bootstrap_concourse/instance.tf
+++ b/terraform/modules/bootstrap_concourse/instance.tf
@@ -1,3 +1,11 @@
+resource "template_file" "pipeline" {
+    template = "${file("${path.module}/assets/pipeline.yml")}"
+
+    vars {
+        aws_default_region = "${var.region}"
+    }
+}
+
 resource "aws_instance" "bootstrap_concourse" {
   ami = "${var.ami_id}"
   instance_type = "${var.instance_type}"
@@ -12,7 +20,7 @@ resource "aws_instance" "bootstrap_concourse" {
 username: ${var.concourse_username}
 password: ${var.concourse_password}
 pipeline: |
-${file("${path.module}/assets/pipeline.yml")}
+${template_file.pipeline.rendered}
 EOF
 
   connection {

--- a/terraform/modules/bootstrap_concourse/instance.tf
+++ b/terraform/modules/bootstrap_concourse/instance.tf
@@ -1,0 +1,22 @@
+resource "aws_instance" "bootstrap_concourse" {
+  ami = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+
+  key_name = "${aws_key_pair.auth.id}"
+
+  security_groups = ["${aws_security_group.bootstrap.name}"]
+
+  iam_instance_profile = "${aws_iam_instance_profile.bootstrap.id}"
+
+  user_data = <<EOF
+username: ${var.concourse_username}
+password: ${var.concourse_password}
+pipeline: |
+${file("${path.module}/assets/pipeline.yml")}
+EOF
+
+  connection {
+    user = "ubuntu"
+  }
+
+}

--- a/terraform/modules/bootstrap_concourse/instance.tf
+++ b/terraform/modules/bootstrap_concourse/instance.tf
@@ -10,8 +10,6 @@ resource "aws_instance" "bootstrap_concourse" {
   ami = "${var.ami_id}"
   instance_type = "${var.instance_type}"
 
-  key_name = "${aws_key_pair.auth.id}"
-
   security_groups = ["${aws_security_group.bootstrap.name}"]
 
   iam_instance_profile = "${aws_iam_instance_profile.bootstrap.id}"

--- a/terraform/modules/bootstrap_concourse/keypair_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/keypair_bootstrap.tf
@@ -1,3 +1,0 @@
-resource "aws_key_pair" "auth" {
-  public_key = "${file("${var.public_key_path}")}"
-}

--- a/terraform/modules/bootstrap_concourse/keypair_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/keypair_bootstrap.tf
@@ -1,0 +1,3 @@
+resource "aws_key_pair" "auth" {
+  public_key = "${file("${var.public_key_path}")}"
+}

--- a/terraform/modules/bootstrap_concourse/ouputs.tf
+++ b/terraform/modules/bootstrap_concourse/ouputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = "http://${var.concourse_username}:${var.concourse_password}@${aws_instance.bootstrap_concourse.public_ip}/login/basic"
+}

--- a/terraform/modules/bootstrap_concourse/ouputs.tf
+++ b/terraform/modules/bootstrap_concourse/ouputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = "http://${var.concourse_username}:${var.concourse_password}@${aws_instance.bootstrap_concourse.public_ip}/login/basic"
+  value = "https://${var.concourse_username}:${var.concourse_password}@${aws_instance.bootstrap_concourse.public_dns}/login/basic"
 }

--- a/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
@@ -1,14 +1,7 @@
 resource "aws_security_group" "bootstrap" {
   ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 80
-    to_port = 80
+    from_port = 443
+    to_port = 443
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/sg_bootstrap.tf
@@ -1,0 +1,22 @@
+resource "aws_security_group" "bootstrap" {
+  ingress {
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/modules/bootstrap_concourse/variables.tf
+++ b/terraform/modules/bootstrap_concourse/variables.tf
@@ -16,3 +16,6 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
+variable "region" {
+  default = "us-gov-west-1"
+}

--- a/terraform/modules/bootstrap_concourse/variables.tf
+++ b/terraform/modules/bootstrap_concourse/variables.tf
@@ -4,12 +4,8 @@ variable "concourse_username" {
   default = "ci"
 }
 
-variable "public_key_path" {
-  default = "~/.ssh/id_rsa.pub"
-}
-
 variable "ami_id" {
-  default = "ami-92338cf3"
+  default = "ami-392c9358"
 }
 
 variable "instance_type" {

--- a/terraform/modules/bootstrap_concourse/variables.tf
+++ b/terraform/modules/bootstrap_concourse/variables.tf
@@ -1,0 +1,18 @@
+variable "concourse_password" {}
+
+variable "concourse_username" {
+  default = "ci"
+}
+
+variable "public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "ami_id" {
+  default = "ami-92338cf3"
+}
+
+variable "instance_type" {
+  default = "t2.micro"
+}
+

--- a/terraform/stacks/bootstrap/outputs.tf
+++ b/terraform/stacks/bootstrap/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = "${module.bootstrap_concourse.endpoint}"
+}

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -1,0 +1,7 @@
+module "bootstrap_concourse" {
+  source = "../../modules/bootstrap_concourse"
+
+  concourse_password = "${var.concourse_password}"
+}
+
+

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -2,9 +2,5 @@ module "bootstrap_concourse" {
   source = "../../modules/bootstrap_concourse"
 
   concourse_password = "${var.concourse_password}"
-
   region = "${var.default_region}"
-
 }
-
-

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -2,6 +2,9 @@ module "bootstrap_concourse" {
   source = "../../modules/bootstrap_concourse"
 
   concourse_password = "${var.concourse_password}"
+
+  region = "${var.default_region}"
+
 }
 
 

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -1,0 +1,17 @@
+variable "concourse_password" {}
+
+variable "concourse_username" {
+  default = "ci"
+}
+
+variable "public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
+}
+
+variable "ami_id" {
+  default = "ami-92338cf3"
+}
+
+variable "instance_type" {
+  default = "t2.micro"
+}

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -1,5 +1,7 @@
 variable "concourse_password" {}
 
+variable "default_region" {}
+
 variable "concourse_username" {
   default = "ci"
 }

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -1,6 +1,8 @@
 variable "concourse_password" {}
 
-variable "default_region" {}
+variable "default_region" {
+  default = "us-gov-west-1"
+}
 
 variable "concourse_username" {
   default = "ci"

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -8,12 +8,8 @@ variable "concourse_username" {
   default = "ci"
 }
 
-variable "public_key_path" {
-  default = "~/.ssh/id_rsa.pub"
-}
-
 variable "ami_id" {
-  default = "ami-92338cf3"
+  default = "ami-392c9358"
 }
 
 variable "instance_type" {

--- a/terraform/stacks/test/test.tf
+++ b/terraform/stacks/test/test.tf
@@ -1,0 +1,7 @@
+resource "aws_security_group" "test_sg" {
+  description = "Test terraform running under bootstrap"
+
+  tags =  {
+    Name = "Test terraform running under bootstrap"
+  }
+}


### PR DESCRIPTION
Add a bootstrap stack which provisions a single ec2 instance in the default VPC running concourse and starts the the pipeline you see in this PR.

That pipeline runs terraform apply using instance profiles for AWS access and deploys the `test` stack successfully (The test stack just creates an empty security group to prove terraform is working).

@LinuxBozo if this looks good to you, I should be able to have it running real stacks tomorrow.  When I start on that, is `cloud-gov` the stack I should be applying? is that the top level?