### PR TITLE
Bootstrap peering

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,10 +3,10 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
   - task: create-update-tooling
     file: pipeline-tasks/terraform-apply.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: tooling
       TEMPLATE_SUBDIR: terraform/stacks/tooling
@@ -35,10 +35,10 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
   - task: create-update-staging
     file: pipeline-tasks/terraform-apply.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: staging
       TEMPLATE_SUBDIR: terraform/stacks/staging
@@ -63,10 +63,10 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
   - task: create-update-production
     file: pipeline-tasks/terraform-apply.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: production
       TEMPLATE_SUBDIR: terraform/stacks/production
@@ -92,11 +92,11 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
       passed: [teardown-staging, teardown-production]
   - task: destroy
     file: pipeline-tasks/terraform-destroy.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: tooling
       TEMPLATE_SUBDIR: terraform/stacks/tooling
@@ -125,11 +125,11 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
       passed: [bootstrap-staging]
   - task: destroy
     file: pipeline-tasks/terraform-destroy.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: staging
       TEMPLATE_SUBDIR: terraform/stacks/staging
@@ -154,11 +154,11 @@ jobs:
   plan:
   - aggregate:
     - get: pipeline-tasks
-    - get: terraform-example
+    - get: cg-provision-repo
       passed: [bootstrap-production]
   - task: destroy
     file: pipeline-tasks/terraform-destroy.yml
-    input_mapping: { terraform-templates: terraform-example }
+    input_mapping: { terraform-templates: cg-provision-repo }
     params:
       STACK_NAME: production
       TEMPLATE_SUBDIR: terraform/stacks/production
@@ -186,8 +186,8 @@ resources:
     uri: https://github.com/18F/cg-pipeline-tasks.git
     branch: master
 
-- name: terraform-example
+- name: cg-provision-repo
   type: git
   source:
     uri: https://github.com/18F/cg-provision.git
-    branch: modules
+    branch: master

--- a/scripts/environment.default.sh
+++ b/scripts/environment.default.sh
@@ -5,7 +5,7 @@
 #
 # To use this file:
 #  1. Copy this file (environment.default.sh) to environment.sh (ignored by Git)
-#  2. Set your AWS account information and other configurations
+#  2. Set everything that is currently blank, and feel free to modify the default values
 #  3. Source these variables into your environment (source environment.sh)
 #  4. Run Terraform as usual (this time without the prompts)
 #
@@ -21,7 +21,7 @@ export TF_VAR_remote_state_bucket=""
 #
 # AWS Account ID of the person running this operation
 #
-export TF_VAR_account_id=""
+export TF_VAR_account_id=`aws ec2 describe-security-groups --group-names "Default" | jq -r ".SecurityGroups[].OwnerId"`
 
 #
 # AWS credentials and default region
@@ -44,4 +44,4 @@ export TF_VAR_default_vpc_route_table=`aws ec2 describe-route-tables --filters N
 #
 # Concourse credentials bucket
 export TF_VAR_credentials_bucket=""
-export TF_VAR_concourse_password="CHANGEME"
+export TF_VAR_concourse_password=""

--- a/scripts/environment.default.sh
+++ b/scripts/environment.default.sh
@@ -33,6 +33,13 @@ export TF_VAR_az1="us-gov-west-1a"
 export TF_VAR_az2="us-gov-west-1b"
 export TF_VAR_aws_access_key_id="${AWS_ACCESS_KEY_ID}"
 export TF_VAR_aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
+export TF_VAR_aws_default_region="${AWS_DEFAULT_REGION}"
+
+#
+# Default VPC
+export TF_VAR_default_vpc_id=`aws ec2 describe-vpcs --filters Name=isDefault,Values=true  | jq -r ".Vpcs[0].VpcId"`
+export TF_VAR_default_vpc_cidr=`aws ec2 describe-vpcs --filters Name=isDefault,Values=true  | jq -r ".Vpcs[0].CidrBlock"`
+export TF_VAR_default_vpc_route_table=`aws ec2 describe-route-tables --filters Name=vpc-id,Values=${TF_VAR_default_vpc_id} | jq -r ".RouteTables[0].RouteTableId"`
 
 #
 # Concourse credentials bucket

--- a/terraform/modules/bootstrap_concourse/assets/pipeline.yml
+++ b/terraform/modules/bootstrap_concourse/assets/pipeline.yml
@@ -14,12 +14,55 @@
           vars_files:
           - credentials/cg-provision.yml
 
+  - name: setup-vpc-peering
+    plan:
+    - get: cg-provision
+    - get: pipeline-tasks
+    - task: connect-peer
+      file: pipeline-tasks/terraform-apply.yml
+      input_mapping: { terraform-templates: cg-provision-repo }
+      params:
+        STACK_NAME: bootstrap-peering
+        TEMPLATE_SUBDIR: terraform/stacks/bootstrap/peering
+        S3_TFSTATE_BUCKET: ${remote_state_bucket}
+        AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+        AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
+        AWS_DEFAULT_REGION: ${aws_default_region}
+        TF_VAR_account_id: ${account_id}
+        TF_VAR_default_vpc_id: ${default_vpc_id}
+        TF_VAR_default_vpc_cidr: ${default_vpc_cidr}
+        TF_VAR_default_vpc_route_table: ${default_vpc_route_table}
+
+  - name: teardown-vpc-peering
+    plan:
+    - get: cg-provision
+    - get: pipeline-tasks
+    - task: destroy-peer
+      file: pipeline-tasks/terraform-destroy.yml
+      input_mapping: { terraform-templates: cg-provision-repo }
+      params:
+        STACK_NAME: bootstrap-peering
+        TEMPLATE_SUBDIR: terraform/stacks/bootstrap/peering
+        S3_TFSTATE_BUCKET: ${remote_state_bucket}
+        AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+        AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
+        AWS_DEFAULT_REGION: ${aws_default_region}
+        TF_VAR_account_id: ${account_id}
+        TF_VAR_default_vpc_id: ${default_vpc_id}
+        TF_VAR_default_vpc_cidr: ${default_vpc_cidr}
+        TF_VAR_default_vpc_route_table: ${default_vpc_route_table}
+
   resources:
   - name: cg-provision
     type: git
     source:
       uri: https://github.com/18F/cg-provision
-      branch: modules
+      branch: master
+  - name: pipeline-tasks
+    type: git
+    source:
+      uri: https://github.com/18F/cg-pipeline-tasks
+      branch: master
   - name: credentials
     type: s3
     source:

--- a/terraform/modules/bootstrap_concourse/instance.tf
+++ b/terraform/modules/bootstrap_concourse/instance.tf
@@ -5,9 +5,14 @@ resource "template_file" "pipeline" {
         aws_access_key_id = "${var.aws_access_key_id}"
         aws_secret_access_key = "${var.aws_secret_access_key}"
         aws_default_region = "${var.aws_default_region}"
+        account_id = "${var.account_id}"
+        remote_state_bucket = "${var.remote_state_bucket}"
         credentials_bucket = "${var.credentials_bucket}"
         concourse_username = "${var.concourse_username}"
         concourse_password = "${var.concourse_password}"
+        default_vpc_id = "${var.default_vpc_id}"
+        default_vpc_cidr = "${var.default_vpc_cidr}"
+        default_vpc_route_table = "${var.default_vpc_route_table}"
     }
 }
 

--- a/terraform/modules/bootstrap_concourse/variables.tf
+++ b/terraform/modules/bootstrap_concourse/variables.tf
@@ -21,3 +21,15 @@ variable "credentials_bucket" {}
 variable "aws_access_key_id" {}
 
 variable "aws_secret_access_key" {}
+
+variable "remote_state_bucket" {
+  default = "terraform-state"
+}
+
+variable "default_vpc_id" {}
+
+variable "default_vpc_cidr" {}
+
+variable "default_vpc_route_table" {}
+
+variable "account_id" {}

--- a/terraform/stacks/bootstrap/peering/tooling_peer.tf
+++ b/terraform/stacks/bootstrap/peering/tooling_peer.tf
@@ -1,0 +1,70 @@
+resource "terraform_remote_state" "tooling_vpc" {
+    backend = "s3"
+    config {
+        bucket = "${var.remote_state_bucket}"
+        key = "tooling/terraform.tfstate"
+    }
+}
+
+# Create peering connection for default_vpc -> tooling
+resource "aws_vpc_peering_connection" "peering" {
+    peer_owner_id = "${var.account_id}"
+    peer_vpc_id = "${terraform_remote_state.tooling_vpc.output.vpc_id}"
+    auto_accept = true
+    vpc_id = "${var.default_vpc_id}"
+
+    tags = {
+        Name = "${var.default_vpc_id} to ${terraform_remote_state.tooling_vpc.output.vpc_id}"
+    }
+}
+
+# Add peering connection to tooling private_route_table_az1 with default_vpc_cidr
+resource "aws_route" "target_az1_to_source_cidr" {
+    route_table_id = "${terraform_remote_state.tooling_vpc.output.private_route_table_az1}"
+    destination_cidr_block = "${var.default_vpc_cidr}"
+    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+}
+
+# Add peering connection to tooling private_route_table_az2 with default_vpc_cidr
+resource "aws_route" "target_az2_to_source_cidr" {
+    route_table_id = "${terraform_remote_state.tooling_vpc.output.private_route_table_az2}"
+    destination_cidr_block = "${var.default_vpc_cidr}"
+    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+}
+
+# add peering connection to default_vpc_route_table with tooling_vpc_cidr
+resource "aws_route" "source_az1_to_target_cidr" {
+    route_table_id = "${var.default_vpc_route_table}"
+    destination_cidr_block = "${terraform_remote_state.tooling_vpc.output.vpc_cidr}"
+    vpc_peering_connection_id = "${aws_vpc_peering_connection.peering.id}"
+}
+
+# Add security group to default_vpc to allow tooling traffic
+resource "aws_security_group" "allow_all_tooling" {
+    name = "allow_all_tooling"
+    description = "Bootstrap allow all from tooling vpc"
+    vpc_id = "${var.default_vpc_id}"
+
+    ingress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = ["${terraform_remote_state.tooling_vpc.output.vpc_cidr}"]
+    }
+
+}
+
+# Add security group to tooling vpc to allow default_vpc traffic
+resource "aws_security_group" "allow_all_tooling" {
+    name = "allow_all_default"
+    description = "Bootstrap allow all from default vpc"
+    vpc_id = "${terraform_remote_state.tooling_vpc.output.vpc_id}"
+
+    ingress {
+        from_port = 0
+        to_port = 0
+        protocol = "-1"
+        cidr_blocks = ["${var.default_vpc_cidr}"]
+    }
+
+}

--- a/terraform/stacks/bootstrap/peering/variables.tf
+++ b/terraform/stacks/bootstrap/peering/variables.tf
@@ -1,0 +1,11 @@
+variable "remote_state_bucket" {
+  default = "terraform-state"
+}
+
+variable "default_vpc_id" {}
+
+variable "default_vpc_cidr" {}
+
+variable "default_vpc_route_table" {}
+
+variable "account_id" {}

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -4,6 +4,11 @@ module "bootstrap_concourse" {
   concourse_password = "${var.concourse_password}"
   aws_access_key_id = "${var.aws_access_key_id}"
   aws_secret_access_key = "${var.aws_secret_access_key}"
+  account_id = "${var.account_id}"
+  remote_state_bucket = "${var.remote_state_bucket}"
   credentials_bucket = "${var.credentials_bucket}"
   aws_default_region = "${var.aws_default_region}"
+  default_vpc_id = "${var.default_vpc_id}"
+  default_vpc_cidr = "${var.default_vpc_cidr}"
+  default_vpc_route_table = "${var.default_vpc_route_table}"
 }

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -21,3 +21,15 @@ variable "credentials_bucket" {}
 variable "aws_access_key_id" {}
 
 variable "aws_secret_access_key" {}
+
+variable "remote_state_bucket" {
+  default = "terraform-state"
+}
+
+variable "default_vpc_id" {}
+
+variable "default_vpc_cidr" {}
+
+variable "default_vpc_route_table" {}
+
+variable "account_id" {}


### PR DESCRIPTION
This adds terraform templates and jobs in our bootstrap concourse to setup and teardown peering from default vpc to tooling vpc so that it can deploy things into the tooling vpc, like masterbosh.