### PR TITLE
Aws broker user

### DIFF
--- a/terraform/modules/iam_user/aws_broker_user/outputs.tf
+++ b/terraform/modules/iam_user/aws_broker_user/outputs.tf
@@ -1,0 +1,11 @@
+output "username" {
+  value = "${module.aws_broker_user.username}"
+}
+
+output "access_key_id" {
+  value = "${module.aws_broker_user.access_key_id}"
+}
+
+output "secret_access_key" {
+  value = "${module.aws_broker_user.secret_access_key}"
+}

--- a/terraform/modules/iam_user/aws_broker_user/user.tf
+++ b/terraform/modules/iam_user/aws_broker_user/user.tf
@@ -1,0 +1,28 @@
+
+module "aws_broker_user" {
+    source = ".."
+
+    username = "${var.username}"
+
+    /* TODO: Make the bucket names configurable */
+    /* TODO: Make sure the bucket arn:path is configurable */
+    iam_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "manageRdsInstances",
+            "Effect": "Allow",
+            "Action": [
+                "rds:DescribeDBInstances",
+                "rds:CreateDBInstance",
+                "rds:DeleteDBInstance"
+            ],
+            "Resource": [
+                "arn:aws-us-gov:rds::${var.account_id}:db:cg-*"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/terraform/modules/iam_user/aws_broker_user/user.tf
+++ b/terraform/modules/iam_user/aws_broker_user/user.tf
@@ -19,7 +19,32 @@ module "aws_broker_user" {
                 "rds:DeleteDBInstance"
             ],
             "Resource": [
-                "arn:aws-us-gov:rds::${var.account_id}:db:cg-*"
+                "arn:aws-us-gov:rds::${var.account_id}:db:cg-aws-broker-*"
+            ]
+        },
+        {
+            "Sid": "readTerraformState",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws-us-gov:s3::${var.account_id}:${var.remote_state_bucket}",
+                "arn:aws-us-gov:s3::${var.account_id}:${var.remote_state_bucket}/*"
+            ]
+        },
+        {
+            "Sid": "manageTerraformState",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws-us-gov:s3::${var.account_id}:${var.remote_state_bucket}/cg-aws-broker-*",
+                "arn:aws-us-gov:s3::${var.account_id}:${var.remote_state_bucket}/cg-aws-broker-*/*"
             ]
         }
     ]

--- a/terraform/modules/iam_user/aws_broker_user/variables.tf
+++ b/terraform/modules/iam_user/aws_broker_user/variables.tf
@@ -1,2 +1,3 @@
 variable "username" {}
 variable "account_id" {}
+variable "remote_state_bucket" {}

--- a/terraform/modules/iam_user/aws_broker_user/variables.tf
+++ b/terraform/modules/iam_user/aws_broker_user/variables.tf
@@ -1,0 +1,2 @@
+variable "username" {}
+variable "account_id" {}

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -164,6 +164,17 @@ output "s3_broker_secret_access_key" {
   value = "${module.s3_broker_user.secret_access_key}"
 }
 
+/* aws broker user */
+output "aws_broker_username" {
+  value = "${module.aws_broker_user.username}"
+}
+output "aws_broker_access_key_id" {
+  value = "${module.aws_broker_user.access_key_id}"
+}
+output "aws_broker_secret_access_key" {
+  value = "${module.aws_broker_user.secret_access_key}"
+}
+
 /* cf cc user */
 output "cf_username" {
   value = "${module.cf_user.username}"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -86,6 +86,12 @@ module "s3_broker_user" {
     account_id = "${var.account_id}"
 }
 
+module "aws_broker_user" {
+    source = "../../modules/iam_user/aws_broker_user"
+    username = "aws-broker"
+    account_id = "${var.account_id}"
+}
+
 module "cloudwatch_user" {
     source = "../../modules/iam_user"
     username = "bosh-cloudwatch"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -90,6 +90,7 @@ module "aws_broker_user" {
     source = "../../modules/iam_user/aws_broker_user"
     username = "aws-broker"
     account_id = "${var.account_id}"
+    remote_state_bucket = "${var.remote_state_bucket}"
 }
 
 module "cloudwatch_user" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -28,6 +28,8 @@ variable "rds_password" {}
 
 variable "account_id" {}
 
+variable "remote_state_bucket" {}
+
 variable "concourse_prod_rds_password" {}
 variable "concourse_prod_cidr" {}
 variable "concourse_prod_elb_cert_name" {


### PR DESCRIPTION
The aws broker pipeline needs to provision a handful of rds instances to store internal state and support shared services. Once deployed, the broker app needs to create, describe, and delete rds instances. Does this look right @LinuxBozo?