### PR TITLE
Reject PUT without encryption.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Manual steps to create the world:
 1. Make sure you have [terraform](https://www.terraform.io/), awscli, and jq installed
  1. Mac OSX users can install all of these with homebrew
 1. Create S3 bucket with versioning enabled to store terraform state: `terraform-state`
-1. Create S3 bucket with versioning enabled to store BOSH manifest secrets for tooling and production: `cloud-gov-varz`
-1. Create S3 bucket with versioning enabled to store BOSH manifest secrets for staging: `cloud-gov-varz-staging`
 1. Create S3 bucket with versioning enabled to store BOSH releases and metadata: `cloud-gov-bosh-releases`
   1. Upload all custom bosh releases
 1. Create S3 bucket to store BOSH stemcell images: `cloud-gov-stemcell-images`

--- a/terraform/modules/bootstrap_buckets/buckets.tf
+++ b/terraform/modules/bootstrap_buckets/buckets.tf
@@ -1,0 +1,56 @@
+module "varz" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.varz_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+}
+
+module "varz_staging" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.varz_staging_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+}
+
+module "concourse_credentials" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.concourse_credentials_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+}
+
+/* TODO: Enable after https://github.com/cloudfoundry/bosh/commit/d473e74ccf9df32e2b38cef0ff40ce1616a3195b#diff-a711787c2157fb23b45c5890b26b9f7d is released
+module "tooling_blobstore" {
+    source = "../s3_bucket/public_encrypted_bucket"
+    bucket = "${var.tooling_blobstore_bucket}"
+    aws_partition = "${var.aws_partition}"
+}
+
+module "staging_blobstore" {
+    source = "../s3_bucket/public_encrypted_bucket"
+    bucket = "${var.staging_blobstore_bucket}"
+    aws_partition = "${var.aws_partition}"
+}
+
+module "production_blobstore" {
+    source = "../s3_bucket/public_encrypted_bucket"
+    bucket = "${var.production_blobstore_bucket}"
+    aws_partition = "${var.aws_partition}"
+}
+*/
+
+/* TODO: Enable after https://github.com/concourse/s3-resource/pull/43 is merged
+module "bosh_release" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.bosh_release_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+}
+
+module "stemcell_images" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.stemcell_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+}
+*/

--- a/terraform/modules/bootstrap_buckets/variables.tf
+++ b/terraform/modules/bootstrap_buckets/variables.tf
@@ -1,0 +1,7 @@
+variable "aws_partition" {}
+
+variable "varz_bucket" {}
+variable "varz_staging_bucket" {}
+variable "concourse_credentials_bucket" {}
+variable "bosh_release_bucket" {}
+variable "stemcell_bucket" {}

--- a/terraform/modules/cloudfoundry/buckets.tf
+++ b/terraform/modules/cloudfoundry/buckets.tf
@@ -1,19 +1,23 @@
-resource "aws_s3_bucket" "cc-resoures" {
+module "cc-resoures" {
+    source = "../s3_bucket/encrypted_bucket"
     bucket = "${var.stack_prefix}-cc-resources"
-    acl = "private"
+    aws_partition = "${var.aws_partition}"
 }
 
-resource "aws_s3_bucket" "buildpacks" {
+module "buildpacks" {
+    source = "../s3_bucket/encrypted_bucket"
     bucket = "${var.stack_prefix}-buildpacks"
-    acl = "private"
+    aws_partition = "${var.aws_partition}"
 }
 
-resource "aws_s3_bucket" "cc-packages" {
+module "cc-packages" {
+    source = "../s3_bucket/encrypted_bucket"
     bucket = "${var.stack_prefix}-cc-packages"
-    acl = "private"
+    aws_partition = "${var.aws_partition}"
 }
 
-resource "aws_s3_bucket" "droplets" {
+module "droplets" {
+    source = "../s3_bucket/encrypted_bucket"
     bucket = "${var.stack_prefix}-droplets"
-    acl = "private"
+    aws_partition = "${var.aws_partition}"
 }

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -1,0 +1,24 @@
+resource "aws_s3_bucket" "encrypted_bucket" {
+    bucket = "${var.bucket}"
+    acl = "${var.acl}"
+
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Sid": "DenyUnencryptedPut",
+        "Effect": "Deny",
+        "Principal": {
+            "AWS": "*"
+        },
+        "Action": "s3:PutObject",
+        "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
+        "Condition": {
+            "StringNotEquals": {
+                "s3:x-amz-server-side-encryption": "AES256"
+            }
+        }
+    }]
+}
+EOF
+}

--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -1,6 +1,9 @@
 resource "aws_s3_bucket" "encrypted_bucket" {
     bucket = "${var.bucket}"
     acl = "${var.acl}"
+    versioning {
+        enabled = "${var.versioning}"
+    }
 
     policy = <<EOF
 {

--- a/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/variables.tf
@@ -1,0 +1,7 @@
+variable "bucket" {}
+
+variable "acl" {
+    default = "private"
+}
+
+variable "aws_partition" {}

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf
@@ -1,0 +1,37 @@
+resource "aws_s3_bucket" "public_encrypted_bucket" {
+    bucket = "${var.bucket}"
+    versioning {
+        enabled = "${var.versioning}"
+    }
+
+    policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowRead",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
+        },
+        {
+            "Sid": "DenyUnencryptedPut",
+            "Effect": "Deny",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
+            "Condition": {
+                "StringNotEquals": {
+                    "s3:x-amz-server-side-encryption": "AES256"
+                }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/modules/s3_bucket/public_encrypted_bucket/variables.tf
+++ b/terraform/modules/s3_bucket/public_encrypted_bucket/variables.tf
@@ -1,9 +1,5 @@
 variable "bucket" {}
 
-variable "acl" {
-    default = "private"
-}
-
 variable "versioning" {
     default = "false"
 }

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -13,3 +13,17 @@ module "bootstrap_concourse" {
   default_vpc_cidr = "${var.default_vpc_cidr}"
   default_vpc_route_table = "${var.default_vpc_route_table}"
 }
+
+module "bootstrap_buckets" {
+    source = "../../modules/bootstrap_buckets"
+    aws_partition = "${var.aws_partition}"
+
+    varz_bucket = "cloud-gov-varz"
+    varz_staging_bucket = "cloud-gov-varz-staging"
+    concourse_credentials_bucket = "concourse-credentials"
+    tooling_blobstore_bucket = "bosh-tooling-blobstore"
+    staging_blobstore_bucket = "bosh-staging-blobstore"
+    production_blobstore_bucket = "bosh-production-blobstore"
+    bosh_release_bucket = "cloud-gov-bosh-releases"
+    stemcell_bucket = "stemcell-images"
+}


### PR DESCRIPTION
Part of https://github.com/18F/cg-atlas/issues/123.

@LinuxBozo: I went with a custom module here to avoid copying and pasting bucket policies, but it occurred to me that this won't be composable with other bucket policies--maybe I should embrace the verbosity of terraform and revert the module. What's your preference?

Note: this should be safe to merge after https://ci.fr.cloud.gov/pipelines/deploy-cf/jobs/deploy-cf-staging/builds/109 and the corresponding production deploy pass, now that they're applying https://github.com/18F/cg-deploy-cf/commit/a7405f19ab2b680f11691e88cd8dceec09cd2a85.