### PR TITLE
Add prevent destroy lifecycle flag.

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -21,6 +21,7 @@ resource "aws_db_instance" "rds_database" {
 
   lifecycle {
     ignore_changes = ["identifier"]
+    prevent_destroy = "${var.rds_prevent_destroy}"
   }
   identifier = "${var.stack_description}-${element(split("-", uuid()),4)}"
 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,3 +1,6 @@
+variable "rds_prevent_destroy" {
+    default = "false"
+}
 
 variable "stack_description" {}
 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,5 +1,5 @@
 variable "rds_prevent_destroy" {
-    default = "false"
+    default = "true"
 }
 
 variable "stack_description" {}


### PR DESCRIPTION
To be used for databases that shouldn't be automatically deleted on
configuration changes.

Specifically, I noticed that the rds instances in the aws broker would have been silently destroyed if we had re-run the concourse pipeline after switching the default encryption from false to true.

@LinuxBozo 