### PR TITLE
Allow cloudwatch user to read metrics.

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -120,7 +120,10 @@ module "cloudwatch_user" {
                 "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
-                "logs:DescribeLogStreams"
+                "logs:DescribeLogStreams",
+                "cloudwatch:ListMetrics",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:GetMetricStatistics"
             ],
             "Resource": [
                 "arn:${var.aws_partition}:logs:*:*:*"


### PR DESCRIPTION
We need an iam user that can read cloudwatch metrics for monitoring services like rds (see https://github.com/riemann/riemann-tools/blob/master/tools/riemann-aws/bin/riemann-aws-rds-status). This patch adds metrics permissions to the existing cloudwatch user. We can also make a separate user with metrics access if that feels safer, but I think this is pretty harmless.

@LinuxBozo 