### PR TITLE
Update cloudwatch resource.

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -125,9 +125,7 @@ module "cloudwatch_user" {
                 "cloudwatch:GetMetricData",
                 "cloudwatch:GetMetricStatistics"
             ],
-            "Resource": [
-                "arn:${var.aws_partition}:logs:*:*:*"
-            ]
+            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
Limiting the `cloudwatch*` actions to the `logs` resource means we can't access metrics, so the policy needs to be updated. As far as I can tell, the current resource of `arn:${var.aws_partition}:logs:*:*:*` effectively grants access to everything logs-related, so I think that `*` is a reasonable way to allow cloudwatch metrics access without changing behavior. But if not, I'll separate the policy into two statements, one for logs and another for metrics.