### PR TITLE
Revert "Add prevent destroy lifecycle flag."

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -21,6 +21,7 @@ resource "aws_db_instance" "rds_database" {
 
   lifecycle {
     ignore_changes = ["identifier"]
+    prevent_destroy = true
   }
   identifier = "${var.stack_description}-${element(split("-", uuid()),4)}"
 

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -21,7 +21,6 @@ resource "aws_db_instance" "rds_database" {
 
   lifecycle {
     ignore_changes = ["identifier"]
-    prevent_destroy = "${var.rds_prevent_destroy}"
   }
   identifier = "${var.stack_description}-${element(split("-", uuid()),4)}"
 

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,6 +1,3 @@
-variable "rds_prevent_destroy" {
-    default = "true"
-}
 
 variable "stack_description" {}
 


### PR DESCRIPTION
This reverts commit bd7c329ca0a4214f8a64faaa48eec930c5f279f4.

My mistake--I should've verified that terraform supports interpolation in lifecycle blocks, and it doesn't (although the feature has been requested, and the team's considering it: https://github.com/hashicorp/terraform/issues/5346). This rolls back the configurable destroy policy I tried to add in #48.

I'm still nervous about the possibility of silently losing RDS data on configuration changes. To prevent that from happening, we could:
* Hard-code `prevent_destroy` to `true` and destroy RDS instances manually
* Make separate `rds_database` and `rds_database_protected` resource (or something)
* Not use the `rds_database` resource for databases that shouldn't be destroyed

Thoughts @LinuxBozo?