### PR TITLE
Temporarily revert prevent_destroy.

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -21,7 +21,8 @@ resource "aws_db_instance" "rds_database" {
 
   lifecycle {
     ignore_changes = ["identifier"]
-    prevent_destroy = true
+    // TODO: Restore `prevent_destroy` after https://github.com/hashicorp/terraform/issues/7728 is resolved
+    // prevent_destroy = true
   }
   identifier = "${var.stack_description}-${element(split("-", uuid()),4)}"
 


### PR DESCRIPTION
Combining `prevent_destroy` with `ignore_changes` on a dynamic variable
effectively makes it impossible to update the relevant resource, as
described in https://github.com/hashicorp/terraform/issues/7728. This
patch reverts the `prevent_destroy` flag on the rds resource. If the
underlying issue is fixed, we can restore this flag. Otherwise, we'll
have to either specify all database identifiers or allow them to be
randomly generated.

@LinuxBozo 