### PR TITLE
Provision kubernetes master and minion users.

### DIFF
--- a/terraform/modules/iam_user/kubernetes_master_user/outputs.tf
+++ b/terraform/modules/iam_user/kubernetes_master_user/outputs.tf
@@ -1,0 +1,11 @@
+output "username" {
+  value = "${module.kubernetes_master_user.username}"
+}
+
+output "access_key_id" {
+  value = "${module.kubernetes_master_user.access_key_id}"
+}
+
+output "secret_access_key" {
+  value = "${module.kubernetes_master_user.secret_access_key}"
+}

--- a/terraform/modules/iam_user/kubernetes_master_user/user.tf
+++ b/terraform/modules/iam_user/kubernetes_master_user/user.tf
@@ -1,0 +1,29 @@
+module "kubernetes_master_user" {
+  source = ".."
+
+  username = "${var.username}"
+  iam_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:*"],
+      "Resource": ["*"]
+    },
+    {
+        "Effect": "Allow",
+        "Action": ["elasticloadbalancing:*"],
+        "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:${var.aws_partition}:s3:::kubernetes-*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/iam_user/kubernetes_master_user/variables.tf
+++ b/terraform/modules/iam_user/kubernetes_master_user/variables.tf
@@ -1,0 +1,2 @@
+variable "username" {}
+variable "aws_partition" {}

--- a/terraform/modules/iam_user/kubernetes_minion_user/outputs.tf
+++ b/terraform/modules/iam_user/kubernetes_minion_user/outputs.tf
@@ -1,0 +1,11 @@
+output "username" {
+  value = "${module.kubernetes_master_user.username}"
+}
+
+output "access_key_id" {
+  value = "${module.kubernetes_master_user.access_key_id}"
+}
+
+output "secret_access_key" {
+  value = "${module.kubernetes_master_user.secret_access_key}"
+}

--- a/terraform/modules/iam_user/kubernetes_minion_user/user.tf
+++ b/terraform/modules/iam_user/kubernetes_minion_user/user.tf
@@ -1,0 +1,35 @@
+module "kubernetes_master_user" {
+  source = ".."
+
+  username = "${var.username}"
+  iam_policy = <<EOF
+
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:${var.aws_partition}:s3:::kubernetes-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:Describe*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:AttachVolume",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DetachVolume",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/iam_user/kubernetes_minion_user/user.tf
+++ b/terraform/modules/iam_user/kubernetes_minion_user/user.tf
@@ -28,6 +28,11 @@ module "kubernetes_master_user" {
       "Effect": "Allow",
       "Action": "ec2:DetachVolume",
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:CreateTags",
+      "Resource": "*"
     }
   ]
 }

--- a/terraform/modules/iam_user/kubernetes_minion_user/variables.tf
+++ b/terraform/modules/iam_user/kubernetes_minion_user/variables.tf
@@ -1,0 +1,2 @@
+variable "username" {}
+variable "aws_partition" {}

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -175,6 +175,28 @@ output "aws_broker_secret_access_key" {
   value = "${module.aws_broker_user.secret_access_key}"
 }
 
+/* kubernetes master user */
+output "kubernetes_master_username" {
+  value = "${module.kubernetes_master_user.username}"
+}
+output "kubernetes_master_access_key_id" {
+  value = "${module.kubernetes_master_user.access_key_id}"
+}
+output "kubernetes_master_secret_access_key" {
+  value = "${module.kubernetes_master_user.secret_access_key}"
+}
+
+/* kubernetes minion user */
+output "kubernetes_minion_username" {
+  value = "${module.kubernetes_minion_user.username}"
+}
+output "kubernetes_minion_access_key_id" {
+  value = "${module.kubernetes_minion_user.access_key_id}"
+}
+output "kubernetes_minion_secret_access_key" {
+  value = "${module.kubernetes_minion_user.secret_access_key}"
+}
+
 /* cf cc user */
 output "cf_username" {
   value = "${module.cf_user.username}"
@@ -205,5 +227,3 @@ output "nessus_elb_dns_name" {
 output "nessus_elb_name" {
   value = "${aws_elb.nessus_elb.name}"
 }
-
-

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -108,6 +108,18 @@ module "aws_broker_user" {
     aws_partition = "${var.aws_partition}"
 }
 
+module "kubernetes_master_user" {
+    source = "../../modules/iam_user/kubernetes_master_user"
+    username = "kubernetes-master"
+    aws_partition = "${var.aws_partition}"
+}
+
+module "kubernetes_minion_user" {
+    source = "../../modules/iam_user/kubernetes_master_user"
+    username = "kubernetes-minion"
+    aws_partition = "${var.aws_partition}"
+}
+
 module "cloudwatch_user" {
     source = "../../modules/iam_user"
     username = "bosh-cloudwatch"


### PR DESCRIPTION
* https://github.com/kubernetes/kubernetes/blob/master/cluster/aws/templates/iam/kubernetes-master-policy.json
* https://github.com/kubernetes/kubernetes/blob/master/cluster/aws/templates/iam/kubernetes-minion-policy.json

Part of https://github.com/18F/cg-atlas/issues/145.

Note: we'll probably want to lock these permissions down more at some point--for now, these are taken exactly from the kubernetes source, minus permissions for services that aren't available in govcloud. We can also track discussion upstream at https://github.com/kubernetes/kubernetes/issues/11936.