### PR TITLE
Tag service subnets with kubernetes cluster tag.

### DIFF
--- a/ci/credentials.yml.example
+++ b/ci/credentials.yml.example
@@ -31,6 +31,7 @@ staging_rds_private_cidr_1: 10.2.5.0/24
 staging_rds_private_cidr_2: 10.2.6.0/24
 staging_services_cidr_1: 10.2.30.0/24
 staging_services_cidr_2: 10.2.31.0/24
+staging_kubernetes_cluster_id: kubernetes-staging
 staging_rds_password: CHANGEME
 staging_cf_rds_password: CHANGEME
 staging_restricted_ingress_web_cidrs: "127.0.0.1/32,192.168.0.1/24"
@@ -44,6 +45,7 @@ production_private_cidr_1: 10.1.1.0/24
 production_private_cidr_2: 10.1.2.0/24
 production_services_cidr_1: 10.1.30.0/24
 production_services_cidr_2: 10.1.31.0/24
+production_kubernetes_cluster_id: kubernetes-production
 production_rds_private_cidr_1: 10.1.5.0/24
 production_rds_private_cidr_2: 10.1.6.0/24
 production_rds_password: CHANGEME

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -125,6 +125,7 @@ jobs:
       TF_VAR_private_cidr_2: {{staging_private_cidr_2}}
       TF_VAR_services_cidr_1: {{staging_services_cidr_1}}
       TF_VAR_services_cidr_2: {{staging_services_cidr_2}}
+      TF_VAR_kubernetes_cluster_id: {{staging_kubernetes_cluster_id}}
       TF_VAR_rds_private_cidr_1: {{staging_rds_private_cidr_1}}
       TF_VAR_rds_private_cidr_2: {{staging_rds_private_cidr_2}}
       TF_VAR_cf_rds_password: {{staging_cf_rds_password}}
@@ -198,6 +199,7 @@ jobs:
       TF_VAR_private_cidr_2: {{production_private_cidr_2}}
       TF_VAR_services_cidr_1: {{production_services_cidr_1}}
       TF_VAR_services_cidr_2: {{production_services_cidr_2}}
+      TF_VAR_kubernetes_cluster_id: {{production_kubernetes_cluster_id}}
       TF_VAR_rds_private_cidr_1: {{production_rds_private_cidr_1}}
       TF_VAR_rds_private_cidr_2: {{production_rds_private_cidr_2}}
       TF_VAR_cf_rds_password: {{production_cf_rds_password}}

--- a/terraform/modules/cloudfoundry/service_subnets.tf
+++ b/terraform/modules/cloudfoundry/service_subnets.tf
@@ -21,6 +21,7 @@ resource "aws_subnet" "az1_services" {
 
   tags =  {
     Name = "${var.stack_description} (Services AZ1)"
+    KubernetesCluster = "${var.kubernetes_cluster_id}"
   }
 }
 
@@ -31,6 +32,7 @@ resource "aws_subnet" "az2_services" {
 
   tags =  {
     Name = "${var.stack_description} (Services AZ2)"
+    KubernetesCluster = "${var.kubernetes_cluster_id}"
   }
 }
 

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -69,3 +69,5 @@ variable "services_cidr_2" {
 }
 
 variable "aws_partition" {}
+
+variable "kubernetes_cluster_id" {}

--- a/terraform/stacks/bootstrap/variables.tf
+++ b/terraform/stacks/bootstrap/variables.tf
@@ -4,6 +4,10 @@ variable "concourse_username" {
   default = "ci"
 }
 
+variable "aws_partition" {
+  default = "aws-us-gov"
+}
+
 variable "aws_default_region" {
     default = "us-gov-west-1"
 }

--- a/terraform/stacks/production/stack.tf
+++ b/terraform/stacks/production/stack.tf
@@ -40,6 +40,7 @@ module "cf" {
     private_route_table_az2 = "${module.stack.private_route_table_az2}"
     services_cidr_1 = "${var.services_cidr_1}"
     services_cidr_2 = "${var.services_cidr_2}"
+    kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
 
     monitoring_elb_cert_name = "${var.monitoring_elb_cert_name}"
     logsearch_elb_cert_name = "${var.logsearch_elb_cert_name}"

--- a/terraform/stacks/production/variables.tf
+++ b/terraform/stacks/production/variables.tf
@@ -46,6 +46,7 @@ variable "apps_cert_name" {
 
 variable "services_cidr_1" {}
 variable "services_cidr_2" {}
+variable "kubernetes_cluster_id" {}
 
 variable "monitoring_elb_cert_name" {
   default = "star-fr-cloud-gov-06-16"

--- a/terraform/stacks/staging/stack.tf
+++ b/terraform/stacks/staging/stack.tf
@@ -40,6 +40,7 @@ module "cf" {
     private_route_table_az2 = "${module.stack.private_route_table_az2}"
     services_cidr_1 = "${var.services_cidr_1}"
     services_cidr_2 = "${var.services_cidr_2}"
+    kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
 
     monitoring_elb_cert_name = "${var.monitoring_elb_cert_name}"
     logsearch_elb_cert_name = "${var.logsearch_elb_cert_name}"

--- a/terraform/stacks/staging/variables.tf
+++ b/terraform/stacks/staging/variables.tf
@@ -46,6 +46,7 @@ variable "apps_cert_name" {
 
 variable "services_cidr_1" {}
 variable "services_cidr_2" {}
+variable "kubernetes_cluster_id" {}
 
 variable "monitoring_elb_cert_name" {
   default = "star-fr-stage-cloud-gov-06-16"
@@ -70,5 +71,3 @@ variable "az2" {
 variable "diego_cidr_1" {}
 
 variable "diego_cidr_2" {}
-
-


### PR DESCRIPTION
The kubernetes AWS cloud provider associates EC2 instances with subnets
by tagging all resources with the `KubernetesCluster` tag. This patch
tags the service subnets with the specified cluster tag; the tag value
must match the value assigned to the EC2 instances provisioned by BOSH.

Goes with https://github.com/18F/kubernetes-release/pull/2.