### PR TITLE
[WIP] Move logging policy to separate role for use with kube2iam.

### DIFF
--- a/terraform/modules/iam_role/kubernetes_logger/role.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/role.tf
@@ -30,4 +30,30 @@ module "kubernetes_logger" {
   ]
 }
 EOF
+  iam_assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+          "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    },
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:${var.aws_partition}:iam::${var.account_id}:role/${var.master_role}",
+          "arn:${var.aws_partition}:iam::${var.account_id}:role/${var.minion_role}"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
 }

--- a/terraform/modules/iam_role/kubernetes_logger/role.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/role.tf
@@ -1,0 +1,33 @@
+module "kubernetes_logger" {
+  source = ".."
+
+  role_name = "${var.role_name}"
+  iam_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ],
+      "Resource": [
+        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:log-group:kubernetes-*"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/iam_role/kubernetes_logger/variables.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/variables.tf
@@ -2,3 +2,5 @@ variable "aws_partition" {}
 variable "aws_default_region" {}
 variable "account_id" {}
 variable "role_name" {}
+variable "master_role" {}
+variable "minion_role" {}

--- a/terraform/modules/iam_role/kubernetes_logger/variables.tf
+++ b/terraform/modules/iam_role/kubernetes_logger/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_partition" {}
+variable "aws_default_region" {}
+variable "account_id" {}
+variable "role_name" {}

--- a/terraform/modules/iam_role/kubernetes_master/role.tf
+++ b/terraform/modules/iam_role/kubernetes_master/role.tf
@@ -27,27 +27,6 @@ module "kubernetes_master" {
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": [
-        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:log-group:kubernetes-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
       "Action": "ec2:CreateTags",
       "Resource": "*"
     },

--- a/terraform/modules/iam_role/kubernetes_minion/role.tf
+++ b/terraform/modules/iam_role/kubernetes_minion/role.tf
@@ -32,27 +32,6 @@ module "kubernetes_minion" {
     },
     {
       "Effect": "Allow",
-      "Action": [
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Resource": [
-        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": [
-        "arn:${var.aws_partition}:logs:${var.aws_default_region}:${var.account_id}:log-group:kubernetes-*"
-      ]
-    },
-    {
-      "Effect": "Allow",
       "Action": "ec2:CreateTags",
       "Resource": "*"
     },

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -146,6 +146,14 @@ module "kubernetes_node_role" {
   minion_role = "k8s-minion"
 }
 
+module "kubernetes_logger_role" {
+  source = "../../modules/iam_role/kubernetes_logger"
+  role_name = "k8s-logger"
+  aws_default_region = "${var.aws_default_region}"
+  aws_partition = "${var.aws_partition}"
+  account_id = "${var.account_id}"
+}
+
 module "cloudwatch_user" {
     source = "../../modules/iam_user"
     username = "bosh-cloudwatch"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -152,6 +152,8 @@ module "kubernetes_logger_role" {
   aws_default_region = "${var.aws_default_region}"
   aws_partition = "${var.aws_partition}"
   account_id = "${var.account_id}"
+  master_role = "k8s-master"
+  minion_role = "k8s-minion"
 }
 
 module "cloudwatch_user" {


### PR DESCRIPTION
Once we switch on kube2iam to proxy iam roles to kubernetes pods, we can drop logging-related permissions from the main kubernetes roles and create a separate kubernetes logging role to be attached to the fluentd-cloudwatch pods.

Part of https://github.com/18F/cg-agent-q/issues/7.