### PR TITLE
Add zoneid output to shibboleth module and stacks

### DIFF
--- a/terraform/modules/shibboleth/outputs.tf
+++ b/terraform/modules/shibboleth/outputs.tf
@@ -8,3 +8,7 @@ output "shibboleth_elb_name" {
 output "shibboleth_elb_dns_name" {
   value = "${aws_elb.shibboleth_elb_main.dns_name}"
 }
+
+output "shibboleth_elb_zone_id" {
+  value = "${aws_elb.shibboleth_elb_main.zone_id}"
+}

--- a/terraform/stacks/production/outputs.tf
+++ b/terraform/stacks/production/outputs.tf
@@ -184,3 +184,7 @@ output "shibboleth_elb_name" {
 output "shibboleth_elb_dns_name" {
   value = "${module.shibboleth.shibboleth_elb_dns_name}"
 }
+
+output "shibboleth_elb_zone_id" {
+  value = "${module.shibboleth.shibboleth_elb_zone_id}"
+}

--- a/terraform/stacks/staging/outputs.tf
+++ b/terraform/stacks/staging/outputs.tf
@@ -173,3 +173,7 @@ output "shibboleth_elb_name" {
 output "shibboleth_elb_dns_name" {
   value = "${module.shibboleth.shibboleth_elb_dns_name}"
 }
+
+output "shibboleth_elb_zone_id" {
+  value = "${module.shibboleth.shibboleth_elb_zone_id}"
+}


### PR DESCRIPTION
This will be the `zone_id` that needs to be updated in 18F/dns#9.