### PR TITLE
Add concourse role.

### DIFF
--- a/terraform/modules/iam_role/concourse_worker/role.tf
+++ b/terraform/modules/iam_role/concourse_worker/role.tf
@@ -1,0 +1,52 @@
+module "concourse" {
+  source = ".."
+
+  role_name = "${var.role_name}"
+  iam_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketAcl",
+        "s3:GetBucketLocation",
+        "s3:GetBucketNotification",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketVersioning",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": [
+        "arn:${var.aws_partition}:s3:::cloud-gov-varz",
+        "arn:${var.aws_partition}:s3:::cloud-gov-varz/*",
+        "arn:${var.aws_partition}:s3:::cloud-gov-varz-stage",
+        "arn:${var.aws_partition}:s3:::cloud-gov-varz-stage/*",
+        "arn:${var.aws_partition}:s3:::cloud-gov-bosh-releases",
+        "arn:${var.aws_partition}:s3:::cloud-gov-bosh-releases/*",
+        "arn:${var.aws_partition}:s3:::cg-stemcell-images",
+        "arn:${var.aws_partition}:s3:::cg-stemcell-images/*",
+        "arn:${var.aws_partition}:s3:::terraform-state",
+        "arn:${var.aws_partition}:s3:::terraform-state/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:${var.aws_partition}:s3:::cloud-gov-varz/master-bosh-state.json"
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/terraform/modules/iam_role/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role/concourse_worker/variables.tf
@@ -1,0 +1,2 @@
+variable "role_name" {}
+variable "aws_partition" {}

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -147,6 +147,12 @@ module "aws_broker_user" {
   aws_partition = "${var.aws_partition}"
 }
 
+module "concourse_worker_role" {
+  source = "../../modules/iam_role/concourse_worker"
+  role_name = "concourse-worker"
+  aws_partition = "${var.aws_partition}"
+}
+
 module "kubernetes_master_role" {
   source = "../../modules/iam_role/kubernetes_master"
   stack_description = "${var.stack_description}"


### PR DESCRIPTION
So that we can bind this to concourse workers and pass fewer secrets around. Note: this is copied exactly from the existing concourse user policy, with the addition of reading from the terraform state bucket so that concourse jobs can get terraform outputs. If we use this and stop using the concourse user, we should eventually drop that resource.