### PR TITLE
Add database credentials to outputs.

### DIFF
--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -1,4 +1,3 @@
-
 output "elb_main_dns_name" {
   value = "${aws_elb.cloudfoundry_elb_main.dns_name}"
 }
@@ -16,15 +15,27 @@ output "elb_apps_name" {
 }
 
 output "cf_rds_url" {
-    value = "${module.cf_database.rds_url}"
+  value = "${module.cf_database.rds_url}"
 }
 
 output "cf_rds_host" {
-    value = "${module.cf_database.rds_host}"
+  value = "${module.cf_database.rds_host}"
 }
 
 output "cf_rds_port" {
-    value = "${module.cf_database.rds_port}"
+  value = "${module.cf_database.rds_port}"
+}
+
+output "cf_rds_username" {
+  value = "${module.cf_database.rds_username}"
+}
+
+output "cf_rds_password" {
+  value = "${module.cf_database.rds_password}"
+}
+
+output "cf_rds_engine" {
+  value = "${module.cf_database.rds_engine}"
 }
 
 /* Services network */

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,13 +1,23 @@
-
 output "rds_url" {
-    value = "${aws_db_instance.rds_database.endpoint}"
+  value = "${aws_db_instance.rds_database.endpoint}"
 }
 
 output "rds_host" {
-    value = "${aws_db_instance.rds_database.address}"
+  value = "${aws_db_instance.rds_database.address}"
 }
 
 output "rds_port" {
-    value = "${aws_db_instance.rds_database.port}"
+  value = "${aws_db_instance.rds_database.port}"
 }
 
+output "rds_username" {
+  value = "${aws_db_instance.rds_database.username}"
+}
+
+output "rds_password" {
+  value = "${aws_db_instance.rds_database.password}"
+}
+
+output "rds_engine" {
+  value = "${aws_db_instance.rds_database.engine}"
+}

--- a/terraform/stacks/production/outputs.tf
+++ b/terraform/stacks/production/outputs.tf
@@ -104,13 +104,22 @@ output "logsearch_elb_name" {
 
 /* CloudFoundry RDS */
 output "cf_rds_url" {
-    value = "${module.cf.cf_rds_url}"
+  value = "${module.cf.cf_rds_url}"
 }
 output "cf_rds_host" {
-    value = "${module.cf.cf_rds_host}"
+  value = "${module.cf.cf_rds_host}"
 }
 output "cf_rds_port" {
-    value = "${module.cf.cf_rds_port}"
+  value = "${module.cf.cf_rds_port}"
+}
+output "cf_rds_username" {
+  value = "${module.cf.cf_rds_username}"
+}
+output "cf_rds_password" {
+  value = "${module.cf.cf_rds_password}"
+}
+output "cf_rds_engine" {
+  value = "${module.cf.cf_rds_engine}"
 }
 
 /* Services Subnets */

--- a/terraform/stacks/staging/outputs.tf
+++ b/terraform/stacks/staging/outputs.tf
@@ -106,13 +106,22 @@ output "logsearch_elb_name" {
 
 /* CloudFoundry RDS */
 output "cf_rds_url" {
-    value = "${module.cf.cf_rds_url}"
+  value = "${module.cf.cf_rds_url}"
 }
 output "cf_rds_host" {
-    value = "${module.cf.cf_rds_host}"
+  value = "${module.cf.cf_rds_host}"
 }
 output "cf_rds_port" {
-    value = "${module.cf.cf_rds_port}"
+  value = "${module.cf.cf_rds_port}"
+}
+output "cf_rds_username" {
+  value = "${module.cf.cf_rds_username}"
+}
+output "cf_rds_password" {
+  value = "${module.cf.cf_rds_password}"
+}
+output "cf_rds_engine" {
+  value = "${module.cf.cf_rds_engine}"
 }
 
 /* Services Subnets */


### PR DESCRIPTION
So that we can avoid copying and pasting database credentials to secrets.