### PR TITLE
Allow aws broker user to modify rds instances.

### DIFF
--- a/terraform/modules/iam_user/aws_broker_user/user.tf
+++ b/terraform/modules/iam_user/aws_broker_user/user.tf
@@ -1,4 +1,3 @@
-
 module "aws_broker_user" {
     source = ".."
 
@@ -16,7 +15,8 @@ module "aws_broker_user" {
             "Action": [
                 "rds:DescribeDBInstances",
                 "rds:CreateDBInstance",
-                "rds:DeleteDBInstance"
+                "rds:DeleteDBInstance",
+                "rds:ModifyDBInstance"
             ],
             "Resource": [
                 "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",


### PR DESCRIPTION
So that aws-broker can update its rds instances when our base config changes--see https://ci.fr.cloud.gov/teams/main/pipelines/deploy-aws-broker/jobs/deploy-aws-broker-staging/builds/68.