### PR TITLE
Add more rds permissions to aws broker.

### DIFF
--- a/terraform/modules/iam_user/aws_broker_user/user.tf
+++ b/terraform/modules/iam_user/aws_broker_user/user.tf
@@ -16,7 +16,9 @@ module "aws_broker_user" {
                 "rds:DescribeDBInstances",
                 "rds:CreateDBInstance",
                 "rds:DeleteDBInstance",
-                "rds:ModifyDBInstance"
+                "rds:ModifyDBInstance",
+                "rds:AddTagsToResource",
+                "rds:RemoveTagsFromResource"
             ],
             "Resource": [
                 "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",


### PR DESCRIPTION
Because it's still failing--terraform wants to be able to change tags too https://ci.fr.cloud.gov/teams/main/pipelines/deploy-aws-broker/jobs/deploy-aws-broker-staging/builds/69