### PR TITLE
Fix tooling rds security groups.

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -23,7 +23,7 @@ module "stack" {
   rds_private_cidr_2 = "${var.rds_private_cidr_2}"
   rds_password = "${var.rds_password}"
   rds_encrypted = true
-  rds_security_groups = ["${module.concourse_production.concourse_security_group}"]
+  rds_security_groups = ["${module.stack.bosh_security_group}"]
 }
 
 module "concourse_production" {


### PR DESCRIPTION
Allow tooling bosh to access its own database. Fixes a regression introduced in https://github.com/18F/cg-product/issues/487.