### PR TITLE
Create trigger for verifying cloud.gov origin

### DIFF
--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -26,7 +26,7 @@ for db in ${DATABASES}; do
   # Special case for Shibboleth, create function and trigger that verifies origin uaa is set to cloud.gov IdP
   # Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
   if [ "${db}" = "uaadb" ]; then
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
     CREATE TABLE IF NOT EXISTS totp_seed
       (
         username varchar(255) PRIMARY KEY,
@@ -34,7 +34,7 @@ for db in ${DATABASES}; do
         backup_code varchar(36)
       )
 EOT
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       ALTER TABLE IF EXISTS totp_seed
         ADD CONSTRAINT username_record_keeper
           FOREIGN KEY (username)
@@ -42,7 +42,7 @@ EOT
           ON DELETE CASCADE
 EOT
 
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       CREATE TABLE IF NOT EXISTS storagerecords
         (
           context varchar(255) NOT NULL,
@@ -54,12 +54,12 @@ EOT
         )
 EOT
 
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       CREATE OR REPLACE FUNCTION "f_isValidEmail"( text ) RETURNS BOOLEAN AS '
       SELECT $1 ~ ''^[^@\s]+@[^@\s]+(\.[^@\s]+)+$'' AS RESULT
       ' LANGUAGE sql
 EOT
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"( text ) RETURNS TRIGGER AS $$
       BEGIN
         UPDATE users
@@ -71,11 +71,11 @@ EOT
       END;
       $$ LANGUAGE plpgsql
 EOT
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       DROP TRIGGER IF EXISTS enforce_cloud_gov_idp_origin_trigger
         ON users
 EOT
-    psql_adm -d "${db}" -c << EOT
+    psql_adm -d "${db}" <<-EOT
       CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
         AFTER UPDATE ON users
         FOR EACH STATEMENT EXECUTE PROCEDURE "f_enforceCloudGovOrigin"()

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -26,14 +26,32 @@ for db in ${DATABASES}; do
   # Special case for Shibboleth, create function and trigger that verifies origin uaa is set to cloud.gov IdP
   # Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
   if [ "${db}" = "uaadb" ]; then
-    psql_adm -d "${db}" -c "CREATE TABLE IF NOT EXISTS totp_seed ( username varchar(255) PRIMARY KEY, seed varchar(36), backup_code varchar(36) )"
-    psql_adm -d "${db}" -c "CREATE TABLE IF NOT EXISTS storagerecords ( context varchar(255) NOT NULL, id varchar(255) NOT NULL, expires bigint DEFAULT NULL, value text NOT NULL, version bigint NOT NULL, PRIMARY KEY (context, id) )"
+    psql_adm -d "${db}" -c << EOT
+    CREATE TABLE IF NOT EXISTS totp_seed
+      (
+        username varchar(255) PRIMARY KEY,
+        seed varchar(36),
+        backup_code varchar(36)
+      )
+EOT
     psql_adm -d "${db}" -c << EOT
       ALTER TABLE IF EXISTS totp_seed
         ADD CONSTRAINT username_record_keeper
           FOREIGN KEY (username)
           REFERENCES users (username)
           ON DELETE CASCADE
+EOT
+
+    psql_adm -d "${db}" -c << EOT
+      CREATE TABLE IF NOT EXISTS storagerecords
+        (
+          context varchar(255) NOT NULL,
+          id varchar(255) NOT NULL,
+          expires bigint DEFAULT NULL,
+          value text NOT NULL,
+          version bigint NOT NULL,
+          PRIMARY KEY (context, id)
+        )
 EOT
 
     psql_adm -d "${db}" -c << EOT

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -72,13 +72,13 @@ EOT
       $$ LANGUAGE plpgsql
 EOT
     psql_adm -d "${db}" <<-EOT
+      BEGIN;
       DROP TRIGGER IF EXISTS enforce_cloud_gov_idp_origin_trigger
-        ON users
-EOT
-    psql_adm -d "${db}" <<-EOT
+        ON users;
       CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
         AFTER UPDATE ON users
-        FOR EACH STATEMENT EXECUTE PROCEDURE "f_enforceCloudGovOrigin"()
+        FOR EACH STATEMENT EXECUTE PROCEDURE "f_enforceCloudGovOrigin"();
+      COMMIT;
 EOT
   fi
 

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -24,9 +24,17 @@ for db in ${DATABASES}; do
   # Special case for uaadb, create totp seed table for use with MFA
   # Special case for Shibboleth, create storage records table for use with multi-zone Shibboleth
   # Special case for Shibboleth, create function and trigger that verifies origin uaa is set to cloud.gov IdP
+  # Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
   if [ "${db}" = "uaadb" ]; then
     psql_adm -d "${db}" -c "CREATE TABLE IF NOT EXISTS totp_seed ( username varchar(255) PRIMARY KEY, seed varchar(36), backup_code varchar(36) )"
     psql_adm -d "${db}" -c "CREATE TABLE IF NOT EXISTS storagerecords ( context varchar(255) NOT NULL, id varchar(255) NOT NULL, expires bigint DEFAULT NULL, value text NOT NULL, version bigint NOT NULL, PRIMARY KEY (context, id) )"
+    psql_adm -d "${db}" -c << EOT
+      ALTER TABLE IF EXISTS totp_seed
+        ADD CONSTRAINT username_record_keeper
+          FOREIGN KEY (username)
+          REFERENCES users (username)
+          ON DELETE CASCADE
+EOT
 
     psql_adm -d "${db}" -c << EOT
       CREATE OR REPLACE FUNCTION "f_isValidEmail"( text ) RETURNS BOOLEAN AS '

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -27,19 +27,21 @@ for db in ${DATABASES}; do
   # Special case for Shibboelth, create FK between totp_seed and users and CASCADE on delete
   if [ "${db}" = "uaadb" ]; then
     psql_adm -d "${db}" <<-EOT
-    CREATE TABLE IF NOT EXISTS totp_seed
-      (
-        username varchar(255) PRIMARY KEY,
-        seed varchar(36),
-        backup_code varchar(36)
-      )
-EOT
-    psql_adm -d "${db}" <<-EOT
+    BEGIN;
+      CREATE TABLE IF NOT EXISTS totp_seed
+        (
+          username varchar(255) PRIMARY KEY,
+          seed varchar(36),
+          backup_code varchar(36)
+        );
+      ALTER TABLE IF EXISTS totp_seed
+        DROP CONSTRAINT username_record_keeper;
       ALTER TABLE IF EXISTS totp_seed
         ADD CONSTRAINT username_record_keeper
           FOREIGN KEY (username)
           REFERENCES users (username)
-          ON DELETE CASCADE
+          ON DELETE CASCADE;
+    COMMIT;
 EOT
 
     psql_adm -d "${db}" <<-EOT

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -64,9 +64,9 @@ EOT
     psql_adm -d "${db}" <<-EOT
       BEGIN;
       CREATE OR REPLACE FUNCTION "f_isValidEmail"( text ) RETURNS BOOLEAN AS '
-      SELECT $1 ~ ''^[^@\s]+@[^@\s]+(\.[^@\s]+)+$'' AS RESULT
-      ' LANGUAGE sql
-      CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"( text ) RETURNS TRIGGER AS $$
+      SELECT \$1 ~ ''^[^@\s]+@[^@\s]+(\.[^@\s]+)+$'' AS RESULT
+      ' LANGUAGE sql;
+      CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"() RETURNS TRIGGER AS \$\$
       BEGIN
         UPDATE users
           SET ( origin, external_id ) = ( 'cloud.gov', username )
@@ -75,7 +75,7 @@ EOT
             verified = true AND
             created::date != passwd_lastmodified::date;
       END;
-      $$ LANGUAGE plpgsql
+      \$\$ LANGUAGE plpgsql;
       COMMIT;
 EOT
     psql_adm -d "${db}" <<-EOT

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -37,7 +37,7 @@ EOT
       CREATE OR REPLACE FUNCTION "f_enforceCloudGovOrigin"( text ) RETURNS TRIGGER AS $$
       BEGIN
         UPDATE users
-          SET ( origin, externalId ) = ( 'cloud.gov', username )
+          SET ( origin, external_id ) = ( 'cloud.gov', username )
           WHERE "f_isValidEmail"( username ) AND
             origin = 'uaa' AND
             verified = true AND

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -46,6 +46,10 @@ EOT
       $$ LANGUAGE plpgsql
 EOT
     psql_adm -d "${db}" -c << EOT
+      DROP TRIGGER IF EXISTS enforce_cloud_gov_idp_origin_trigger
+        ON users
+EOT
+    psql_adm -d "${db}" -c << EOT
       CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
         AFTER UPDATE ON users
         FOR EACH STATEMENT EXECUTE PROCEDURE "f_enforceCloudGovOrigin"()

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -40,8 +40,8 @@ EOT
           SET ( origin, externalId ) = ( 'cloud.gov', username )
           WHERE "f_isValidEmail"( username ) AND
             origin = 'uaa' AND
-            verified = false AND
-            created::date = passwd_lastmodified::date;
+            verified = true AND
+            created::date != passwd_lastmodified::date;
       END;
       $$ LANGUAGE plpgsql
 EOT

--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -47,8 +47,8 @@ EOT
 EOT
     psql_adm -d "${db}" -c << EOT
       CREATE TRIGGER enforce_cloud_gov_idp_origin_trigger
-        AFTER INSERT OR UPDATE ON users
-        FOR EACH ROW EXECUTE PROCEDURE "f_enforceCloudGovOrigin"()
+        AFTER UPDATE ON users
+        FOR EACH STATEMENT EXECUTE PROCEDURE "f_enforceCloudGovOrigin"()
 EOT
   fi
 


### PR DESCRIPTION
Thanks to @cnelson's advice on using Triggers, we can now verify that whenever we update a user in the DB we'll enforce that cloud.gov users are properly set up.

I verified that the `verified` is set to false and that `created` and `passwd_lastmodified` match by inviting a test user. I think this might be all we need. But I'd appreciate extra eyes on this.

cc: @linuxbozo