### PR TITLE
add a user that has read-only access to cloud-gov-bosh-releases 

### DIFF
--- a/terraform/modules/iam_user/concourse_user_east/outputs.tf
+++ b/terraform/modules/iam_user/concourse_user_east/outputs.tf
@@ -1,0 +1,11 @@
+output "username" {
+  value = "${module.concourse_user_east.username}"
+}
+
+output "access_key_id" {
+  value = "${module.concourse_user_east.access_key_id}"
+}
+
+output "secret_access_key" {
+  value = "${module.concourse_user_east.secret_access_key}"
+}

--- a/terraform/modules/iam_user/concourse_user_east/user.tf
+++ b/terraform/modules/iam_user/concourse_user_east/user.tf
@@ -1,0 +1,38 @@
+
+module "concourse_user_east" {
+    source = ".."
+
+    username = "${var.username}"
+
+    /* TODO: Make the bucket names configurable */
+    iam_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation",
+                "s3:GetBucketNotification",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketVersioning",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListBucketVersions",
+                "s3:ListMultipartUploadParts"
+            ],
+            "Resource": [
+                "arn:${var.aws_partition}:s3:::cloud-gov-bosh-releases",
+                "arn:${var.aws_partition}:s3:::cloud-gov-bosh-releases/*"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/terraform/modules/iam_user/concourse_user_east/variables.tf
+++ b/terraform/modules/iam_user/concourse_user_east/variables.tf
@@ -1,0 +1,2 @@
+variable "username" {}
+variable "aws_partition" {}

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -179,6 +179,18 @@ output "ci_secret_access_key" {
   value = "${module.ci_user.secret_access_key}"
 }
 
+/* ci user to access bosh secrets */
+output "ci_east_username" {
+  value = "${module.ci_user_east.username}"
+}
+output "ci_east_access_key_id" {
+  value = "${module.ci_user_east.access_key_id}"
+}
+output "ci_east_secret_access_key" {
+  value = "${module.ci_user_east.secret_access_key}"
+}
+
+
 /* release user to write release blobs */
 output "release_username" {
   value = "${module.release_user.username}"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -113,6 +113,13 @@ module "ci_user" {
   aws_partition = "${var.aws_partition}"
 }
 
+# This user WILL be removed once east has been shutdown.  DO NOT USE these credentials in the GovCloud environment
+module "ci_user_east" {
+  source = "../../modules/iam_user/concourse_user_east"
+  username = "concourse-east"
+  aws_partition = "${var.aws_partition}"
+}
+
 module "cf_user" {
   source = "../../modules/iam_user/cf_user"
   username = "cf-cc-s3"


### PR DESCRIPTION
so the east deployment can consume them