### PR TITLE
Length limit the concourse elb name to 32 chars or less

### DIFF
--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -1,6 +1,6 @@
 
 resource "aws_elb" "concourse_elb" {
-  name = "${var.stack_description}-Concourse-${var.concourse_az}"
+  name = "${replace("${var.stack_description}-Concourse-${var.concourse_az}", "/(.{0,32})(.*)/", "$1")}"
   subnets = ["${split(",", var.elb_subnets)}"]
   security_groups = ["${split(",", var.elb_security_groups)}"]
   idle_timeout = 3600


### PR DESCRIPTION
Should solve the error we see in production stack.