### PR TITLE
Add permissions for rds broker acceptance tests.

### DIFF
--- a/terraform/modules/iam_user/aws_broker_user/user.tf
+++ b/terraform/modules/iam_user/aws_broker_user/user.tf
@@ -19,10 +19,13 @@ module "aws_broker_user" {
                 "rds:ModifyDBInstance",
                 "rds:AddTagsToResource",
                 "rds:ListTagsForResource",
-                "rds:RemoveTagsFromResource"
+                "rds:RemoveTagsFromResource",
+                "rds:DescribeDBSnapshots",
+                "rds:DeleteDBSnapshot"
             ],
             "Resource": [
                 "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:db:cg-aws-broker-*",
+                "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:snapshot:cg-aws-broker-*",
                 "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:subgrp:production",
                 "arn:${var.aws_partition}:rds:${var.aws_default_region}:${var.account_id}:subgrp:staging"
             ]


### PR DESCRIPTION
Alternatively, since these permissions are only needed for running the acceptance tests, we could make a separate user for tests and leave this permissions out for the broker user. WDYT?