### PR TITLE
Add a temporary bucket with a one day expiration

### DIFF
--- a/terraform/modules/bootstrap_buckets/buckets.tf
+++ b/terraform/modules/bootstrap_buckets/buckets.tf
@@ -50,3 +50,11 @@ module "stemcell_images" {
     aws_partition = "${var.aws_partition}"
     versioning = "true"
 }
+
+module "tmp" {
+    source = "../s3_bucket/encrypted_bucket"
+    bucket = "${var.tmp_bucket}"
+    aws_partition = "${var.aws_partition}"
+    versioning = "true"
+    expiration_days = 1
+}

--- a/terraform/modules/bootstrap_buckets/variables.tf
+++ b/terraform/modules/bootstrap_buckets/variables.tf
@@ -8,3 +8,4 @@ variable "staging_blobstore_bucket" {}
 variable "production_blobstore_bucket" {}
 variable "bosh_release_bucket" {}
 variable "stemcell_bucket" {}
+variable "tmp_bucket" {}

--- a/terraform/stacks/bootstrap/stack.tf
+++ b/terraform/stacks/bootstrap/stack.tf
@@ -26,4 +26,5 @@ module "bootstrap_buckets" {
   production_blobstore_bucket = "bosh-production-blobstore"
   bosh_release_bucket = "cloud-gov-bosh-releases"
   stemcell_bucket = "cg-stemcell-images"
+  tmp_bucket = "cloud-gov-tmp"
 }


### PR DESCRIPTION
When debugging problems in production I've needed to get large files (java hprof files, huge logs, etc) from production hosts to my laptop for analysis.  I've been doing this by copying files from the production hosts to s3, and then from s3 down to my laptop.

This PR formalizes a space for these kinds of transfers and ensures data is purged daily so we don't leave sensitive data in a bucket if we forget to cleanup after ourselves.

WDYT?

