### PR TITLE
Upgrade concourse databases.

### DIFF
--- a/terraform/modules/concourse/outputs.tf
+++ b/terraform/modules/concourse/outputs.tf
@@ -13,6 +13,9 @@ output "concourse_security_group" {
 output "concourse_rds_identifier" {
   value = "${module.rds.rds_identifier}"
 }
+output "concourse_rds_96_identifier" {
+  value = "${module.rds_96.rds_identifier}"
+}
 
 output "concourse_rds_name" {
   value = "${module.rds.rds_name}"

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -1,16 +1,30 @@
-
-
 module "rds" {
-    source = "../rds"
+  source = "../rds"
 
-    stack_description = "${var.stack_description}"
-    rds_db_name = "${var.rds_db_name}"
-    rds_instance_type = "${var.rds_instance_type}"
-    rds_db_storage_type = "${var.rds_db_storage_type}"
-    rds_db_size = "${var.rds_db_size}"
-    rds_username = "${var.rds_username}"
-    rds_password = "${var.rds_password}"
-    rds_subnet_group = "${var.rds_subnet_group}"
-    rds_security_groups = "${var.rds_security_groups}"
-    rds_encrypted = "${var.rds_encrypted}"
+  stack_description = "${var.stack_description}"
+  rds_db_name = "${var.rds_db_name}"
+  rds_instance_type = "${var.rds_instance_type}"
+  rds_db_storage_type = "${var.rds_db_storage_type}"
+  rds_db_size = "${var.rds_db_size}"
+  rds_username = "${var.rds_username}"
+  rds_password = "${var.rds_password}"
+  rds_subnet_group = "${var.rds_subnet_group}"
+  rds_security_groups = "${var.rds_security_groups}"
+  rds_encrypted = "${var.rds_encrypted}"
+}
+
+module "rds_96" {
+  source = "../rds"
+
+  stack_description = "${var.stack_description}"
+  rds_db_name = "${var.rds_db_name}"
+  rds_instance_type = "${var.rds_instance_type}"
+  rds_db_storage_type = "${var.rds_db_storage_type}"
+  rds_db_size = "${var.rds_db_size}"
+  rds_db_engine_version = "${var.rds_engine_version}"
+  rds_username = "${var.rds_username}"
+  rds_password = "${var.rds_password}"
+  rds_subnet_group = "${var.rds_subnet_group}"
+  rds_security_groups = "${var.rds_security_groups}"
+  rds_encrypted = "${var.rds_encrypted}"
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -1,4 +1,3 @@
-
 variable "stack_description" {}
 
 variable "concourse_cidr" {
@@ -22,7 +21,11 @@ variable "rds_db_storage_type" {
 }
 
 variable "rds_instance_type" {
-    default = "db.m3.xlarge"
+  default = "db.m3.xlarge"
+}
+
+variable "rds_engine_version" {
+  default = "9.6.1"
 }
 
 variable "rds_username" {

--- a/terraform/stacks/production/outputs.tf
+++ b/terraform/stacks/production/outputs.tf
@@ -205,6 +205,9 @@ output "concourse_security_group" {
 output "concourse_rds_identifier" {
   value = "${module.concourse.concourse_rds_identifier}"
 }
+output "concourse_rds_96_identifier" {
+  value = "${module.concourse.concourse_rds_96_identifier}"
+}
 output "concourse_rds_name" {
   value = "${module.concourse.concourse_rds_name}"
 }

--- a/terraform/stacks/staging/outputs.tf
+++ b/terraform/stacks/staging/outputs.tf
@@ -196,6 +196,9 @@ output "concourse_security_group" {
 output "concourse_rds_identifier" {
   value = "${module.concourse.concourse_rds_identifier}"
 }
+output "concourse_rds_96_identifier" {
+  value = "${module.concourse.concourse_rds_96_identifier}"
+}
 output "concourse_rds_name" {
   value = "${module.concourse.concourse_rds_name}"
 }

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -127,6 +127,9 @@ output "production_concourse_security_group" {
 output "production_concourse_rds_identifier" {
   value = "${module.concourse_production.concourse_rds_identifier}"
 }
+output "production_concourse_rds_96_identifier" {
+  value = "${module.concourse_production.concourse_rds_96_identifier}"
+}
 output "production_concourse_rds_name" {
   value = "${module.concourse_production.concourse_rds_name}"
 }


### PR DESCRIPTION
Only outputting identifiers on the 9.6.1 instances, since everything else should be the same.