### PR TITLE
[WIP] Set rds to use ssd by default.

### DIFF
--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -11,5 +11,4 @@ module "cf_database_96" {
     rds_password = "${var.rds_password}"
     rds_subnet_group = "${var.rds_subnet_group}"
     rds_security_groups = "${var.rds_security_groups}"
-    rds_encrypted = true
 }

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -4,12 +4,10 @@ module "rds_96" {
   stack_description = "${var.stack_description}"
   rds_db_name = "${var.rds_db_name}"
   rds_instance_type = "${var.rds_instance_type}"
-  rds_db_storage_type = "${var.rds_db_storage_type}"
   rds_db_size = "${var.rds_db_size}"
   rds_db_engine_version = "${var.rds_engine_version}"
   rds_username = "${var.rds_username}"
   rds_password = "${var.rds_password}"
   rds_subnet_group = "${var.rds_subnet_group}"
   rds_security_groups = "${var.rds_security_groups}"
-  rds_encrypted = "${var.rds_encrypted}"
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -16,10 +16,6 @@ variable "rds_db_size" {
   default = 10
 }
 
-variable "rds_db_storage_type" {
-  default = "gp2"
-}
-
 variable "rds_instance_type" {
   default = "db.m3.xlarge"
 }
@@ -30,10 +26,6 @@ variable "rds_engine_version" {
 
 variable "rds_username" {
   default = "atc"
-}
-
-variable "rds_encrypted" {
-  default = true
 }
 
 variable "rds_password" {}

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "rds_database" {
   username = "${var.rds_username}"
   password = "${var.rds_password}"
 
-  storage_encrypted = "${var.rds_encrypted}"
+  storage_encrypted = true
 
   db_subnet_group_name = "${var.rds_subnet_group}"
   vpc_security_group_ids = ["${split(",", var.rds_security_groups)}"]

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -9,7 +9,7 @@ variable "rds_db_size" {
 }
 
 variable "rds_db_storage_type" {
-    default = "standard"
+    default = "gp2"
 }
 
 variable "rds_db_name" {
@@ -33,7 +33,3 @@ variable "rds_password" {}
 variable "rds_subnet_group" {}
 
 variable "rds_security_groups" {}
-
-variable "rds_encrypted" {
-    default = true
-}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -41,5 +41,4 @@ module "rds_96" {
     rds_password = "${var.rds_password}"
     rds_subnet_group = "${module.rds_network.rds_subnet_group}"
     rds_security_groups = "${module.rds_network.rds_postgres_security_group},${module.rds_network.rds_mysql_security_group}"
-    rds_encrypted = "${var.rds_encrypted}"
 }

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -52,10 +52,6 @@ variable "rds_instance_type" {
     default = "db.m3.medium"
 }
 
-variable "rds_db_storage_type" {
-    default = "standard"
-}
-
 variable "rds_db_size" {
     default = 5
 }
@@ -74,10 +70,6 @@ variable "rds_db_engine_version" {
 
 variable "rds_username" {
     default = "postgres"
-}
-
-variable "rds_encrypted" {
-    default = true
 }
 
 variable "rds_password" {}

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -28,7 +28,6 @@ module "base" {
     rds_db_engine_version = "${var.rds_db_engine_version}"
     rds_username = "${var.rds_username}"
     rds_password = "${var.rds_password}"
-    rds_encrypted = "${var.rds_encrypted}"
     restricted_ingress_web_cidrs = "${var.restricted_ingress_web_cidrs}"
     rds_security_groups = [
       "${module.base.bosh_security_group}",

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -52,10 +52,6 @@ variable "rds_instance_type" {
     default = "db.m3.medium"
 }
 
-variable "rds_db_storage_type" {
-    default = "standard"
-}
-
 variable "rds_db_size" {
     default = 5
 }
@@ -74,10 +70,6 @@ variable "rds_db_engine_version" {
 
 variable "rds_username" {
     default = "postgres"
-}
-
-variable "rds_encrypted" {
-    default = true
 }
 
 variable "restricted_ingress_web_cidrs" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -13,7 +13,6 @@ module "stack" {
     rds_private_cidr_2 = "${var.rds_private_cidr_2}"
     restricted_ingress_web_cidrs = "${var.restricted_ingress_web_cidrs}"
     rds_password = "${var.rds_password}"
-    rds_encrypted = true
     account_id = "${var.account_id}"
     remote_state_bucket = "${var.remote_state_bucket}"
     target_stack_name = "${var.target_stack_name}"
@@ -118,7 +117,6 @@ module "concourse" {
   rds_subnet_group = "${module.stack.rds_subnet_group}"
   rds_security_groups = "${module.stack.rds_postgres_security_group},${module.stack.rds_mysql_security_group}"
   rds_instance_type = "db.m3.medium"
-  rds_encrypted = true
   account_id = "${var.account_id}"
   elb_cert_name = "${var.concourse_elb_cert_name}"
   elb_subnets = "${module.stack.public_subnet_az2}"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -22,7 +22,6 @@ module "stack" {
   rds_private_cidr_1 = "${var.rds_private_cidr_1}"
   rds_private_cidr_2 = "${var.rds_private_cidr_2}"
   rds_password = "${var.rds_password}"
-  rds_encrypted = true
   rds_security_groups = ["${module.stack.bosh_security_group}"]
 }
 
@@ -37,9 +36,7 @@ module "concourse_production" {
   rds_password = "${var.concourse_prod_rds_password}"
   rds_subnet_group = "${module.stack.rds_subnet_group}"
   rds_security_groups = "${module.stack.rds_postgres_security_group},${module.stack.rds_mysql_security_group}"
-  rds_encrypted = true
   rds_instance_type = "db.m3.xlarge"
-  rds_db_storage_type = "gp2"
   account_id = "${var.account_id}"
   elb_cert_name = "${var.concourse_prod_elb_cert_name}"
   elb_subnets = "${module.stack.public_subnet_az1}"
@@ -58,7 +55,6 @@ module "concourse_staging" {
   rds_subnet_group = "${module.stack.rds_subnet_group}"
   rds_security_groups = "${module.stack.rds_postgres_security_group},${module.stack.rds_mysql_security_group}"
   rds_instance_type = "db.m3.medium"
-  rds_encrypted = true
   account_id = "${var.account_id}"
   elb_cert_name = "${var.concourse_staging_elb_cert_name}"
   elb_subnets = "${module.stack.public_subnet_az2}"


### PR DESCRIPTION
Note: let's schedule a maintenance window before merging.

This also hard-codes encryption to true and stops passing storage types across modules, since setting the default at the rds module level is good enough for the foreseeable future.