### PR TITLE
Allow ingress on node exporter port from tooling monitoring.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -355,6 +355,7 @@ jobs:
       TF_VAR_bucket_prefix: staging-cg
       TF_VAR_blobstore_bucket_name: bosh-staging-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
+      TF_VAR_target_monitoring_security_group_count: 1
 
 - name: bootstrap-staging
   plan:

--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -105,6 +105,16 @@ resource "aws_security_group_rule" "bosh_director" {
     security_group_id = "${aws_security_group.bosh.id}"
 }
 
+resource "aws_security_group_rule" "node_exporter" {
+    count = "${var.monitoring_security_group_count}"
+    type = "ingress"
+    from_port = 9100
+    to_port = 9100
+    protocol = "tcp"
+    source_security_group_id = "${var.monitoring_security_group}"
+    security_group_id = "${aws_security_group.bosh.id}"
+}
+
 resource "aws_security_group_rule" "outbound" {
     type = "egress"
     from_port = 0

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -43,3 +43,10 @@ variable "nat_gateway_instance_type" {
 variable "nat_gateway_ami" {
   default = "ami-e8ab1489"
 }
+
+variable "monitoring_security_group" {
+  default = ""
+}
+variable "monitoring_security_group_count" {
+  default = 0
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -13,6 +13,8 @@ module "vpc" {
     restricted_ingress_web_cidrs = "${var.restricted_ingress_web_cidrs}"
     nat_gateway_instance_type = "${var.nat_gateway_instance_type}"
     nat_gateway_ami = "${var.nat_gateway_ami}"
+    monitoring_security_group = "${var.target_monitoring_security_group}"
+    monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -81,3 +81,10 @@ variable "restricted_ingress_web_cidrs" {
 variable "rds_security_groups" {
   type = "list"
 }
+
+variable "target_monitoring_security_group" {
+  default = ""
+}
+variable "target_monitoring_security_group_count" {
+  default = 0
+}

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -25,6 +25,8 @@ module "base" {
       "${module.base.bosh_security_group}",
       "${var.target_bosh_security_group}"
     ]
+    target_monitoring_security_group = "${var.target_monitoring_security_group}"
+    target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
 }
 
 module "vpc_peering" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -87,3 +87,10 @@ variable "target_vpc_cidr" {}
 variable "target_bosh_security_group" {}
 variable "target_az1_route_table" {}
 variable "target_az2_route_table" {}
+
+variable "target_monitoring_security_group" {
+  default = ""
+}
+variable "target_monitoring_security_group_count" {
+  default = 0
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -28,6 +28,8 @@ module "stack" {
     target_bosh_security_group = "${data.terraform_remote_state.target_vpc.bosh_security_group}"
     target_az1_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az1}"
     target_az2_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az2}"
+    target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
+    target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
 }
 
 module "cf" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -78,3 +78,7 @@ variable "upstream_blobstore_bucket_name" {}
 variable "force_restricted_network" {
   default = "yes"
 }
+
+variable "target_monitoring_security_group_count" {
+  default = 0
+}


### PR DESCRIPTION
Only in the staging environment for now.

@LinuxBozo 