### PR TITLE
[WIP] Add vpc dns addresses.

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -12,6 +12,9 @@ output "vpc_id" {
 output "vpc_cidr" {
   value = "${module.stack.vpc_cidr}"
 }
+output "vpc_cidr_dns" {
+  value = "${cidrhost("${module.stack.vpc_cidr}", 2)}"
+}
 
 /* Private network */
 output "private_subnet_az1" {

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -85,6 +85,19 @@ output "staging_monitoring_subnet_gateway" {
   value = "${cidrhost("${var.monitoring_staging_cidr}", 1)}"
 }
 
+output "production_monitoring_riemann_address" {
+  value = "${cidrhost("${var.monitoring_production_cidr}", 128)}"
+}
+output "production_monitoring_influxdb_address" {
+  value = "${cidrhost("${var.monitoring_production_cidr}", 129)}"
+}
+output "staging_monitoring_riemann_address" {
+  value = "${cidrhost("${var.monitoring_staging_cidr}", 128)}"
+}
+output "staging_monitoring_influxdb_address" {
+  value = "${cidrhost("${var.monitoring_staging_cidr}", 129)}"
+}
+
 output "master_bosh_static_ip" {
   value = "${cidrhost("${var.private_cidr_1}", 6)}"
 }

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -15,6 +15,9 @@ output "vpc_id" {
 output "vpc_cidr" {
   value = "${module.stack.vpc_cidr}"
 }
+output "vpc_cidr_dns" {
+  value = "${cidrhost("${module.stack.vpc_cidr}", 2)}"
+}
 
 /* Private network */
 output "private_subnet_az1" {


### PR DESCRIPTION
We're also outputting per-subnet dns addresses, but our bosh deployments seem to be using vpc-level dns addresses. WDYT @cnelson @LinuxBozo ?