### PR TITLE
Output reserved subnet ranges.

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -220,6 +220,9 @@ output "concourse_subnet_cidr" {
 output "concourse_subnet_gateway" {
   value = "${cidrhost("${module.concourse.concourse_subnet_cidr}", 1)}"
 }
+output "concourse_subnet_reserved" {
+  value = "${cidrhost("${module.concourse.concourse_subnet_cidr}", 0)} - ${cidrhost("${module.concourse.concourse_subnet_cidr}", 3)}"
+}
 output "concourse_security_group" {
   value = "${module.concourse.concourse_security_group}"
 }

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -48,6 +48,14 @@ output "private_subnet_az2_zone" {
   value = "${var.az2}"
 }
 
+output "private_subnet_az1_reserved" {
+  value = "${cidrhost("${var.private_cidr_1}", 0)} - ${cidrhost("${var.private_cidr_1}", 3)}"
+}
+
+output "private_subnet_az2_reserved" {
+  value = "${cidrhost("${var.private_cidr_2}", 0)} - ${cidrhost("${var.private_cidr_2}", 3)}"
+}
+
 output "private_subnet_az1_gateway" {
   value = "${cidrhost("${var.private_cidr_1}", 1)}"
 }
@@ -62,6 +70,13 @@ output "private_subnet_az1_dns" {
 
 output "private_subnet_az2_dns" {
   value = "${cidrhost("${var.private_cidr_2}", 2)}"
+}
+
+output "production_monitoring_subnet_reserved" {
+  value = "${cidrhost("${var.monitoring_production_cidr}", 0)} - ${cidrhost("${var.monitoring_production_cidr}", 3)}"
+}
+output "staging_monitoring_subnet_reserved" {
+  value = "${cidrhost("${var.monitoring_staging_cidr}", 0)} - ${cidrhost("${var.monitoring_staging_cidr}", 3)}"
 }
 
 output "production_monitoring_subnet_dns" {
@@ -177,6 +192,9 @@ output "bosh_rds_password" {
 output "production_concourse_subnet" {
   value = "${module.concourse_production.concourse_subnet}"
 }
+output "production_concourse_subnet_reserved" {
+  value = "${cidrhost("${module.concourse_production.concourse_subnet_cidr}", 0)} - ${cidrhost("${module.concourse_production.concourse_subnet_cidr}", 3)}"
+}
 output "production_concourse_subnet_cidr" {
   value = "${module.concourse_production.concourse_subnet_cidr}"
 }
@@ -217,6 +235,9 @@ output "production_concourse_elb_name" {
 /* Staging Concourse */
 output "staging_concourse_subnet" {
   value = "${module.concourse_staging.concourse_subnet}"
+}
+output "staging_concourse_subnet_reserved" {
+  value = "${cidrhost("${module.concourse_staging.concourse_subnet_cidr}", 0)} - ${cidrhost("${module.concourse_staging.concourse_subnet_cidr}", 3)}"
 }
 output "staging_concourse_subnet_cidr" {
   value = "${module.concourse_staging.concourse_subnet_cidr}"


### PR DESCRIPTION
So that we can set reserved ranges in cg-deploy-bosh and fix issues like https://ci.fr.cloud.gov/teams/main/pipelines/deploy-monitoring/jobs/deploy-monitoring-staging/builds/468.