### PR TITLE
Allow ingress to main stack logsearch from concourse.

### DIFF
--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -115,6 +115,16 @@ resource "aws_security_group_rule" "node_exporter" {
     security_group_id = "${aws_security_group.bosh.id}"
 }
 
+resource "aws_security_group_rule" "concourse_logsearch" {
+    count = "${var.concourse_security_group_count}"
+    type = "ingress"
+    from_port = 9200
+    to_port = 9200
+    protocol = "tcp"
+    source_security_group_id = "${element(var.concourse_security_groups, count.index)}"
+    security_group_id = "${aws_security_group.bosh.id}"
+}
+
 resource "aws_security_group_rule" "outbound" {
     type = "egress"
     from_port = 0

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -50,3 +50,11 @@ variable "monitoring_security_group" {
 variable "monitoring_security_group_count" {
   default = 0
 }
+
+variable "concourse_security_groups" {
+  type = "list"
+  default = []
+}
+variable "concourse_security_group_count" {
+  default = "0"
+}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -15,6 +15,8 @@ module "vpc" {
     nat_gateway_ami = "${var.nat_gateway_ami}"
     monitoring_security_group = "${var.target_monitoring_security_group}"
     monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    concourse_security_groups = "${var.target_concourse_security_groups}"
+    concourse_security_group_count = "${var.target_concourse_security_group_count}"
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -88,3 +88,11 @@ variable "target_monitoring_security_group" {
 variable "target_monitoring_security_group_count" {
   default = 0
 }
+
+variable "target_concourse_security_groups" {
+  type = "list"
+  default = []
+}
+variable "target_concourse_security_group_count" {
+  default = "0"
+}

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -27,6 +27,8 @@ module "base" {
     ]
     target_monitoring_security_group = "${var.target_monitoring_security_group}"
     target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    target_concourse_security_groups = "${var.target_concourse_security_groups}"
+    target_concourse_security_group_count = "${var.target_concourse_security_group_count}"
 }
 
 module "vpc_peering" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -94,3 +94,11 @@ variable "target_monitoring_security_group" {
 variable "target_monitoring_security_group_count" {
   default = 0
 }
+
+variable "target_concourse_security_groups" {
+  type = "list"
+  default = []
+}
+variable "target_concourse_security_group_count" {
+  default = "0"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -30,6 +30,11 @@ module "stack" {
     target_az2_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az2}"
     target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
     target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    target_concourse_security_groups = [
+      "${data.terraform_remote_state.target_vpc.production_concourse_security_group}",
+      "${data.terraform_remote_state.target_vpc.staging_concourse_security_group}"
+    ]
+    target_concourse_security_group_count = 2
 }
 
 module "cf" {


### PR DESCRIPTION
We could also lock this down further by adding a security group for logsearch instead of allowing ingress to the bosh security group. WDYT @cnelson ?