### PR TITLE
Allow concourse workers to inspect in-use IAM certificates

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -51,6 +51,14 @@
         "arn:${aws_partition}:s3:::${varz_bucket}/master-bosh-state.json",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "iam:GetServerCertificate"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
for: https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-5057

I will move this to whatever role we create for privileged concourse tasks when we get to that story.

