### PR TITLE
Bump concourse database disk.

### DIFF
--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -17,7 +17,7 @@ variable "rds_parameter_group_name" {
 }
 
 variable "rds_db_size" {
-  default = 10
+  default = 20
 }
 
 variable "rds_instance_type" {


### PR DESCRIPTION
Because usage jumped after upgrading to concourse 3.0.