### PR TITLE
Bump databases to 9.6.2

### DIFF
--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -5,7 +5,7 @@ module "cf_database_96" {
     rds_instance_type = "${var.rds_instance_type}"
     rds_db_size = "${var.rds_db_size}"
     rds_db_engine = "${var.rds_db_engine}"
-    rds_db_engine_version = "${var.rds_db_engine_version}"
+    rds_db_engine_version = "${var.stack_prefix == "cf-production" ? "9.6.1" : var.rds_db_engine_version}"
     rds_db_name = "${var.rds_db_name}"
     rds_username = "${var.rds_username}"
     rds_password = "${var.rds_password}"

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -27,7 +27,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "${var.stack_prefix == "cf-production" ? "9.6.1" : "9.6.2"}"
+    default = "9.6.2"
 }
 
 variable "rds_username" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -27,7 +27,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.1"
+    default = "9.6.2"
 }
 
 variable "rds_username" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -27,7 +27,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.2"
+    default = "${var.stack_prefix == "cf-production" ? "9.6.1" : "9.6.2"}"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -23,7 +23,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.1"
+  default = "9.6.2"
 }
 
 variable "rds_username" {}

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -65,7 +65,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.1"
+    default = "9.6.2"
 }
 
 variable "rds_username" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -65,7 +65,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.1"
+    default = "9.6.2"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
Excluding:

* Concourse databases - Until we know what's going on with performance
* CF production - Until we see how long staging takes and can schedule a maint window
