### PR TITLE
Use the new certificates

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -347,10 +347,10 @@ jobs:
       TF_VAR_diego_cidr_2: {{staging_diego_cidr_2}}
       TF_VAR_concourse_rds_password: {{staging_vpc_concourse_rds_password}}
       TF_VAR_concourse_cidr: {{staging_vpc_concourse_cidr}}
-      TF_VAR_main_cert_name: star-fr-stage-cloud-gov-06-16
-      TF_VAR_apps_cert_name: star-fr-stage-cloud-gov-06-16
-      TF_VAR_elb_shibboleth_cert_name: star-fr-stage-cloud-gov-06-16
-      TF_VAR_concourse_elb_cert_name: star-fr-stage-cloud-gov-06-16
+      TF_VAR_main_cert_name: star-fr-stage-cloud-gov-2017-05
+      TF_VAR_apps_cert_name: star-fr-stage-cloud-gov-2017-05
+      TF_VAR_elb_shibboleth_cert_name: star-fr-stage-cloud-gov-2017-05
+      TF_VAR_concourse_elb_cert_name: star-fr-stage-cloud-gov-2017-05
       TF_VAR_stack_prefix: cf-staging
       TF_VAR_bucket_prefix: staging-cg
       TF_VAR_blobstore_bucket_name: bosh-staging-blobstore
@@ -454,10 +454,10 @@ jobs:
       TF_VAR_diego_cidr_2: {{production_diego_cidr_2}}
       TF_VAR_concourse_rds_password: {{production_vpc_concourse_rds_password}}
       TF_VAR_concourse_cidr: {{production_vpc_concourse_cidr}}
-      TF_VAR_main_cert_name: star-fr-cloud-gov-06-16
+      TF_VAR_main_cert_name: star-fr-cloud-gov-2017-05
       TF_VAR_apps_cert_name: star-app-cloud-gov-16
-      TF_VAR_elb_shibboleth_cert_name: star-fr-cloud-gov-06-16
-      TF_VAR_concourse_elb_cert_name: star-fr-cloud-gov-06-16
+      TF_VAR_elb_shibboleth_cert_name: star-fr-cloud-gov-2017-05
+      TF_VAR_concourse_elb_cert_name: star-fr-cloud-gov-2017-05
       TF_VAR_18f_gov_elb_cert_name: star-18f-gov-04-17
       TF_VAR_stack_prefix: cf-production
       TF_VAR_bucket_prefix: cg

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -62,7 +62,7 @@ variable "diego_cidr_1" {}
 variable "diego_cidr_2" {}
 
 variable "elb_shibboleth_cert_name" {
-  default = "star-fr-cloud-gov-06-16"
+  default = "star-fr-cloud-gov-2017-05"
 }
 
 /* Variables for customer concourse service */

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -40,31 +40,31 @@ variable "remote_state_bucket" {}
 variable "concourse_prod_rds_password" {}
 variable "concourse_prod_cidr" {}
 variable "concourse_prod_elb_cert_name" {
-    default = "star-fr-cloud-gov-06-16"
+    default = "star-fr-cloud-gov-2017-05"
 }
 
 variable "concourse_staging_rds_password" {}
 variable "concourse_staging_cidr" {}
 variable "concourse_staging_elb_cert_name" {
-    default = "star-fr-stage-cloud-gov-06-16"
+    default = "star-fr-stage-cloud-gov-2017-05"
 }
 
 variable "monitoring_production_cidr" {}
 variable "monitoring_production_elb_cert_name" {
-    default = "star-fr-cloud-gov-06-16"
+    default = "star-fr-cloud-gov-2017-05"
 }
 
 variable "monitoring_staging_cidr" {}
 variable "monitoring_staging_elb_cert_name" {
-    default = "star-fr-stage-cloud-gov-06-16"
+    default = "star-fr-stage-cloud-gov-2017-05"
 }
 
 variable "nessus_elb_cert_name" {
-  default = "star-fr-cloud-gov-06-16"
+  default = "star-fr-cloud-gov-2017-05"
 }
 
 variable "bosh_uaa_elb_cert_name" {
-    default = "star-fr-cloud-gov-06-16"
+    default = "star-fr-cloud-gov-2017-05"
 }
 
 variable "restricted_ingress_web_cidrs" {}


### PR DESCRIPTION
Our existing ones expire in a few weeks.

We might want to flip monitoring by hand in the console to make sure the certs work before deploying this everywhere.  🤷‍♂️ 