### PR TITLE
Remove references to East-West

### DIFF
--- a/ci/credentials.yml.example
+++ b/ci/credentials.yml.example
@@ -9,10 +9,10 @@ aws_access_key_id: ACCESS_KEY_ID
 aws_secret_access_key: SECRET_ACCESS_KEY
 aws_account_id: XXXXXXXXXXXX
 aws_partition: aws
-aws_default_region: us-east-1
+aws_default_region: us-gov-west-1
 aws_s3_tfstate_bucket: MY_TERRAFORM_BUCKET
-aws_az1: us-east-1b
-aws_az2: us-east-1d
+aws_az1: us-gov-west-1b
+aws_az2: us-gov-west-1d
 
 tooling_vpc_cidr: 10.0.0.0/16
 tooling_public_cidr_1: 10.0.3.0/24

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -372,23 +372,6 @@ output "ci_secret_access_key_curr" {
   value = "${module.ci_user.secret_access_key_curr}"
 }
 
-/* ci user to access bosh secrets */
-output "ci_east_username" {
-  value = "${module.ci_user_east.username}"
-}
-output "ci_east_access_key_id_prev" {
-  value = "${module.ci_user_east.access_key_id_prev}"
-}
-output "ci_east_secret_access_key_prev" {
-  value = "${module.ci_user_east.secret_access_key_prev}"
-}
-output "ci_east_access_key_id_curr" {
-  value = "${module.ci_user_east.access_key_id_curr}"
-}
-output "ci_east_secret_access_key_curr" {
-  value = "${module.ci_user_east.secret_access_key_curr}"
-}
-
 /* release user to write release blobs */
 output "release_username" {
   value = "${module.release_user.username}"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -125,13 +125,6 @@ module "ci_user" {
   aws_partition = "${var.aws_partition}"
 }
 
-# This user WILL be removed once east has been shutdown.  DO NOT USE these credentials in the GovCloud environment
-module "ci_user_east" {
-  source = "../../modules/iam_user/concourse_user_east"
-  username = "concourse-east"
-  aws_partition = "${var.aws_partition}"
-}
-
 module "release_user" {
   source = "../../modules/iam_user/release_user"
   username = "releaser"


### PR DESCRIPTION
This PR does the following:
* Remove East-West-related credentials
* Change sample credentials to use `us-gov-west` instead of `us-east`

https://favro.com/card/1e11108a2da81e3bd7153a7a/18F-4826