### PR TITLE
Drop ASG instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,3 @@ macOS users can install all of these with [`homebrew`](http://brew.sh/).
   1. Update the pipeline to use proper stemcell
   1. Fly the pipeline
   1. Verify the pipeline runs successfully
-1. After CloudFoundry is successfully deployed, make sure it has a `security-group` called `internal_access` that includes any private subnets within that installation that tenant applications should be able to access, e.g.
-
-    ```json
-    [
-      {
-        "destination": "10.0.50.0-10.0.51.255",
-        "protocol": "all"
-      }
-    ]
-    ```


### PR DESCRIPTION
This is now managed by a separate terraform config