### PR TITLE
Update for terraform 0.9.x.

### DIFF
--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
 module "cdn_broker" {
   source = "../../modules/cdn_broker"
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -1,3 +1,7 @@
+terraform {
+  backend "s3" {}
+}
+
 data "terraform_remote_state" "target_vpc" {
   backend = "s3"
   config {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -6,6 +6,10 @@
  * in each module, which declares these defaults.
  */
 
+terraform {
+  backend "s3" {}
+}
+
 module "stack" {
   source = "../../modules/stack/base"
 

--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,7 @@ status=0
 
 for dir in $dirs; do
   echo "Validating terraform directory $dir"
-  terraform get $dir > /dev/null && terraform graph $dir > /dev/null || status=1
+  terraform validate ${dir} || status=1
 done
 
-exit $status
+exit ${status}


### PR DESCRIPTION
Goes with https://github.com/18F/cg-deploy-concourse-docker-image/pull/25.