### PR TITLE
Change "roles" to "role" for instance profiles.

### DIFF
--- a/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
+++ b/terraform/modules/bootstrap_concourse/iam_role_bootstrap.tf
@@ -19,7 +19,7 @@ resource "aws_iam_instance_profile" "bootstrap" {
   lifecycle {
     ignore_changes = ["name"]
   }
-  roles = ["${aws_iam_role.bootstrap.name}"]
+  role = "${aws_iam_role.bootstrap.name}"
 }
 
 resource "aws_iam_role_policy" "bootstrap" {

--- a/terraform/modules/iam_role/role.tf
+++ b/terraform/modules/iam_role/role.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role" "iam_role" {
 
 resource "aws_iam_instance_profile" "iam_profile" {
   name = "${var.role_name}"
-  roles = ["${aws_iam_role.iam_role.name}"]
+  role = "${aws_iam_role.iam_role.name}"
 }
 
 resource "aws_iam_role_policy" "iam_policy" {


### PR DESCRIPTION
Fixes "[DEPRECATED] Use `role` instead" warnings.