### PR TITLE
drop old aws access, they've been rotated

### DIFF
--- a/terraform/modules/cdn_broker/outputs.tf
+++ b/terraform/modules/cdn_broker/outputs.tf
@@ -2,10 +2,10 @@ output "username" {
   value = "${var.username}"
 }
 output "access_key_id_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.id}"
+  value = ""
 }
 output "secret_access_key_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.secret}"
+  value = ""
 }
 output "access_key_id_curr" {
   value = "${aws_iam_access_key.iam_access_key_v3.id}"

--- a/terraform/modules/cdn_broker/resources.tf
+++ b/terraform/modules/cdn_broker/resources.tf
@@ -24,10 +24,6 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
   user = "${aws_iam_user.iam_user.name}"
 }
 
-resource "aws_iam_access_key" "iam_access_key_v2" {
-  user = "${aws_iam_user.iam_user.name}"
-}
-
 resource "aws_iam_user_policy" "iam_policy" {
   name = "${aws_iam_user.iam_user.name}-policy"
   user = "${aws_iam_user.iam_user.name}"

--- a/terraform/modules/iam_user/billing_user/outputs.tf
+++ b/terraform/modules/iam_user/billing_user/outputs.tf
@@ -2,10 +2,10 @@ output "username" {
   value = "${var.username}"
 }
 output "access_key_id_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v1.id}"
+  value = ""
 }
 output "secret_access_key_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v1.secret}"
+  value = ""
 }
 output "access_key_id_curr" {
   value = "${aws_iam_access_key.iam_access_key_v2.id}"

--- a/terraform/modules/iam_user/billing_user/user.tf
+++ b/terraform/modules/iam_user/billing_user/user.tf
@@ -15,10 +15,6 @@ resource "aws_iam_access_key" "iam_access_key_v2" {
   user = "${aws_iam_user.iam_user.name}"
 }
 
-resource "aws_iam_access_key" "iam_access_key_v1" {
-  user = "${aws_iam_user.iam_user.name}"
-}
-
 resource "aws_iam_user_policy" "iam_policy" {
   name = "${aws_iam_user.iam_user.name}-policy"
   user = "${aws_iam_user.iam_user.name}"

--- a/terraform/modules/iam_user/limit_check_user/outputs.tf
+++ b/terraform/modules/iam_user/limit_check_user/outputs.tf
@@ -2,10 +2,10 @@ output "username" {
   value = "${var.username}"
 }
 output "access_key_id_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.id}"
+  value = ""
 }
 output "secret_access_key_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.secret}"
+  value = ""
 }
 output "access_key_id_curr" {
   value = "${aws_iam_access_key.iam_access_key_v3.id}"

--- a/terraform/modules/iam_user/limit_check_user/user.tf
+++ b/terraform/modules/iam_user/limit_check_user/user.tf
@@ -10,10 +10,6 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
   user = "${aws_iam_user.iam_user.name}"
 }
 
-resource "aws_iam_access_key" "iam_access_key_v2" {
-  user = "${aws_iam_user.iam_user.name}"
-}
-
 resource "aws_iam_user_policy" "iam_policy" {
   name = "${aws_iam_user.iam_user.name}-policy"
   user = "${aws_iam_user.iam_user.name}"

--- a/terraform/modules/iam_user/stemcell_user/outputs.tf
+++ b/terraform/modules/iam_user/stemcell_user/outputs.tf
@@ -2,10 +2,10 @@ output "username" {
   value = "${var.username}"
 }
 output "access_key_id_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.id}"
+  value = ""
 }
 output "secret_access_key_prev" {
-  value = "${aws_iam_access_key.iam_access_key_v2.secret}"
+  value = ""
 }
 output "access_key_id_curr" {
   value = "${aws_iam_access_key.iam_access_key_v3.id}"

--- a/terraform/modules/iam_user/stemcell_user/user.tf
+++ b/terraform/modules/iam_user/stemcell_user/user.tf
@@ -14,10 +14,6 @@ resource "aws_iam_access_key" "iam_access_key_v3" {
   user = "${aws_iam_user.iam_user.name}"
 }
 
-resource "aws_iam_access_key" "iam_access_key_v2" {
-  user = "${aws_iam_user.iam_user.name}"
-}
-
 resource "aws_iam_user_policy" "iam_policy" {
   name = "${aws_iam_user.iam_user.name}-policy"
   user = "${aws_iam_user.iam_user.name}"


### PR DESCRIPTION
Limit check successfully run with new keys:
- https://ci.fr.cloud.gov/teams/main/pipelines/deploy-limit-check/jobs/run-limit-checker-east/builds/148

cdn-broker with new keys: 
- https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cdn-broker/jobs/acceptance-tests-staging/builds/96
- https://ci.fr.cloud.gov/teams/main/pipelines/deploy-cdn-broker/jobs/acceptance-tests-production/builds/32

stemcell with new keys:
- https://ci.fr.cloud.gov/teams/main/pipelines/aws-light-stemcell-builder/jobs/publish-ubuntu-hvm/builds/131

billing user confirmed ok by @jcscottiii: 
- https://gsa-tts.slack.com/archives/C4XLJ1JBV/p1498234187616636

