### PR TITLE
Allow bosh security group ingress on kubernetes node ports.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -225,6 +225,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: cg-provision-repo
+      resource: cg-provision-repo-development
       trigger: true
     - get: plan-timer
       trigger: true
@@ -279,6 +280,7 @@ jobs:
   - aggregate:
     - get: pipeline-tasks
     - get: cg-provision-repo
+      resource: cg-provision-repo-development
       passed: [plan-bootstrap-development]
   - task: create-update-development
     tags:
@@ -655,6 +657,12 @@ resources:
   source:
     uri: {{cg_provision_git_url}}
     branch: {{cg_provision_git_branch}}
+
+- name: cg-provision-repo-development
+  type: git
+  source:
+    uri: {{cg_provision_development_git_url}}
+    branch: {{cg_provision_development_git_branch}}
 
 - name: pull-request
   type: pull-request

--- a/terraform/modules/kubernetes/sg_bosh.tf
+++ b/terraform/modules/kubernetes/sg_bosh.tf
@@ -1,9 +1,0 @@
-/* Allow Kubernetes VMs to access BOSH registry */
-resource "aws_security_group_rule" "bosh_registry" {
-  type = "ingress"
-  from_port = 25777
-  to_port = 25777
-  protocol = "tcp"
-  source_security_group_id = "${aws_security_group.kubernetes_ec2.id}"
-  security_group_id = "${var.target_bosh_security_group}"
-}

--- a/terraform/modules/kubernetes/sg_ec2.tf
+++ b/terraform/modules/kubernetes/sg_ec2.tf
@@ -34,6 +34,15 @@ resource "aws_security_group_rule" "consul_dns" {
   security_group_id = "${aws_security_group.kubernetes_ec2.id}"
 }
 
+resource "aws_security_group_rule" "node_ports" {
+  type = "ingress"
+  from_port = 30000
+  to_port = 32767
+  protocol = "tcp"
+  source_security_group_id = "${var.target_bosh_security_group}"
+  security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+}
+
 resource "aws_security_group_rule" "outbound" {
   type = "egress"
   from_port = 0
@@ -80,4 +89,13 @@ resource "aws_security_group_rule" "bosh_director" {
   protocol = "tcp"
   cidr_blocks = ["${var.vpc_cidr}"]
   security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+}
+
+resource "aws_security_group_rule" "bosh_registry" {
+  type = "ingress"
+  from_port = 25777
+  to_port = 25777
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.kubernetes_ec2.id}"
+  security_group_id = "${var.target_bosh_security_group}"
 }


### PR DESCRIPTION
To verify: test that cf applications can access k8s services when this configuration is applied but not otherwise.