### PR TITLE
Add internal logsearch load balancer.

### DIFF
--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -20,7 +20,7 @@ resource "aws_elb" "kubernetes_elb" {
     interval = 30
   }
 
-  tags = {
+  tags {
     Name = "${var.stack_description}-kubernetes"
   }
 }

--- a/terraform/modules/kubernetes/sg_ec2.tf
+++ b/terraform/modules/kubernetes/sg_ec2.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "kubernetes_ec2" {
   description = "Allow access to incoming kubernetes traffic"
   vpc_id = "${var.vpc_id}"
 
-  tags = {
+  tags {
     Name = "${var.stack_description} - Kubernetes EC2"
   }
 }

--- a/terraform/modules/kubernetes/sg_elb.tf
+++ b/terraform/modules/kubernetes/sg_elb.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "kubernetes_elb" {
   description = "Allow access to incoming kubernetes traffic"
   vpc_id = "${var.vpc_id}"
 
-  tags = {
+  tags {
     Name = "${var.stack_description} - Kubernetes ELB"
   }
 }

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -1,0 +1,26 @@
+resource "aws_elb" "logsearch_elb" {
+  name = "${var.stack_description}-logsearch"
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.bosh_security_group}"]
+  idle_timeout = 3600
+  internal = true
+
+  listener {
+    instance_port = 9200
+    instance_protocol = "tcp"
+    lb_port = 9200
+    lb_protocol = "tcp"
+  }
+
+  health_check {
+    healthy_threshold = 2
+    unhealthy_threshold = 10
+    timeout = 5
+    target = "HTTP:9200/_cluster/health?local"
+    interval = 30
+  }
+
+  tags {
+    Name = "${var.stack_description}-logsearch"
+  }
+}

--- a/terraform/modules/logsearch/outputs.tf
+++ b/terraform/modules/logsearch/outputs.tf
@@ -1,0 +1,7 @@
+/* Logsearch ELB */
+output "logsearch_elb_name" {
+  value = "${aws_elb.logsearch_elb.name}"
+}
+output "logsearch_elb_dns_name" {
+  value = "${aws_elb.logsearch_elb.dns_name}"
+}

--- a/terraform/modules/logsearch/variables.tf
+++ b/terraform/modules/logsearch/variables.tf
@@ -1,0 +1,4 @@
+variable "stack_description" {}
+variable "vpc_id" {}
+variable "elb_subnets" {type = "list"}
+variable "bosh_security_group" {}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -270,6 +270,14 @@ output "kubernetes_ec2_security_group" {
   value = "${module.kubernetes.kubernetes_ec2_security_group}"
 }
 
+/* Logsearch network */
+output "logsearch_elb_name" {
+  value = "${module.logsearch.logsearch_elb_name}"
+}
+output "logsearch_elb_dns_name" {
+  value = "${module.logsearch.logsearch_elb_dns_name}"
+}
+
 /* Client ELBs */
 output "client_elb_star_18f_gov_name" {
   value = "${module.client-elbs.star_18f_gov_elb_name}"

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -101,6 +101,15 @@ module "kubernetes" {
     target_concourse_security_group = "${data.terraform_remote_state.target_vpc.production_concourse_security_group}"
 }
 
+module "logsearch" {
+    source = "../../modules/logsearch"
+
+    stack_description = "${var.stack_description}"
+    vpc_id = "${module.stack.vpc_id}"
+    elb_subnets = ["${module.cf.services_subnet_az1}","${module.cf.services_subnet_az2}"]
+    bosh_security_group = "${module.stack.bosh_security_group}"
+}
+
 module "client-elbs" {
     source = "../../modules/client-elbs"
 


### PR DESCRIPTION
So that external tasks and jobs, like cg-billing and cg-deploy-kubernetes, can find elastic masters by load balancer instead of using static ips.