### PR TITLE
Configure monitoring ingress for all main stacks.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -385,7 +385,6 @@ jobs:
       TF_VAR_bucket_prefix: staging-cg
       TF_VAR_blobstore_bucket_name: bosh-staging-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
-      TF_VAR_target_monitoring_security_group_count: 1
       TF_VAR_use_nat_gateway_eip: "true"
   - *notify-slack
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -33,7 +33,7 @@ module "stack" {
     target_az1_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az1}"
     target_az2_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az2}"
     target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
-    target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    target_monitoring_security_group_count = 1
     target_concourse_security_groups = [
       "${data.terraform_remote_state.target_vpc.production_concourse_security_group}",
       "${data.terraform_remote_state.target_vpc.staging_concourse_security_group}"

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -79,10 +79,6 @@ variable "force_restricted_network" {
   default = "yes"
 }
 
-variable "target_monitoring_security_group_count" {
-  default = 0
-}
-
 variable "use_nat_gateway_eip" {
   default = false
 }


### PR DESCRIPTION
We originally added a configurable count to test this feature on staging. Now this is ready for production, so we can hard-code the counts.