### PR TITLE
Allow ingress to secureproxy from concourse.

### DIFF
--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -135,6 +135,16 @@ resource "aws_security_group_rule" "concourse_logsearch" {
     security_group_id = "${aws_security_group.bosh.id}"
 }
 
+resource "aws_security_group_rule" "concourse_secureproxy" {
+    count = "${var.concourse_security_group_count}"
+    type = "ingress"
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    source_security_group_id = "${element(var.concourse_security_groups, count.index)}"
+    security_group_id = "${aws_security_group.bosh.id}"
+}
+
 resource "aws_security_group_rule" "outbound" {
     type = "egress"
     from_port = 0


### PR DESCRIPTION
So that smoke tests running on concourse can access secureproxy without
going across the load balancer.

Marking `[WIP]` until tests are passing on dev.