### PR TITLE
Limit aws broker policy access to relevant rds subgroup.

### DIFF
--- a/terraform/modules/iam_role_policy/aws_broker/policy.json
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.json
@@ -23,8 +23,7 @@
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:db:cg-aws-broker-*",
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:pg:cg-aws-broker-*",
         "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:snapshot:cg-aws-broker-*",
-        "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:subgrp:production",
-        "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:subgrp:staging"
+        "arn:${aws_partition}:rds:${aws_default_region}:${account_id}:subgrp:${rds_subgroup}"
       ]
     },
     {

--- a/terraform/modules/iam_role_policy/aws_broker/policy.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/policy.tf
@@ -6,6 +6,7 @@ data "template_file" "policy" {
     aws_default_region = "${var.aws_default_region}"
     aws_partition = "${var.aws_partition}"
     remote_state_bucket = "${var.remote_state_bucket}"
+    rds_subgroup = "${var.rds_subgroup}"
   }
 }
 

--- a/terraform/modules/iam_role_policy/aws_broker/variables.tf
+++ b/terraform/modules/iam_role_policy/aws_broker/variables.tf
@@ -3,3 +3,4 @@ variable "account_id" {}
 variable "aws_partition" {}
 variable "aws_default_region" {}
 variable "remote_state_bucket" {}
+variable "rds_subgroup" {}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -255,6 +255,7 @@ module "aws_broker_policy" {
   aws_partition = "${var.aws_partition}"
   aws_default_region = "${var.aws_default_region}"
   remote_state_bucket = "${var.remote_state_bucket}"
+  rds_subgroup = "${var.stack_description}"
 }
 
 module "default_role" {


### PR DESCRIPTION
@sharms 