### PR TITLE
Bump non-prod & non concourse postgres to 9.6.3

### DIFF
--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -5,7 +5,7 @@ module "cf_database_96" {
     rds_instance_type = "${var.rds_instance_type}"
     rds_db_size = "${var.rds_db_size}"
     rds_db_engine = "${var.rds_db_engine}"
-    rds_db_engine_version = "${var.rds_db_engine_version}"
+    rds_db_engine_version = "${var.stack_prefix == "cf-production" ? "9.6.2" : var.rds_db_engine_version}"
     rds_db_name = "${var.rds_db_name}"
     rds_username = "${var.rds_username}"
     rds_password = "${var.rds_password}"

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -27,7 +27,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.2"
+    default = "9.6.3"
 }
 
 variable "rds_username" {

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -23,7 +23,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-  default = "9.6.2"
+  default = "9.6.3"
 }
 
 variable "rds_username" {}

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -61,7 +61,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.2"
+    default = "9.6.3"
 }
 
 variable "rds_username" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -61,7 +61,7 @@ variable "rds_db_engine" {
 }
 
 variable "rds_db_engine_version" {
-    default = "9.6.2"
+    default = "9.6.3"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
Similar to https://github.com/18F/cg-provision/pull/249
Excluding:
- Concourse databases - Until we know what's going on with performance
- CF production - Until we see how long staging takes and can schedule a
maint window
By deploying to our non-prod, we can prepare to fix the POAM issue of
outdated databases

TODO: don't want to try this on a Friday afternoon where I'm about to log off