### PR TITLE
[WIP] Bump concourse postgres to 9.6.3

### DIFF
--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -33,7 +33,7 @@ variable "rds_instance_type" {
 }
 
 variable "rds_engine_version" {
-  default = "9.6.2"
+  default = "9.6.3"
 }
 
 variable "rds_username" {


### PR DESCRIPTION
Similar to https://github.com/18F/cg-provision/pull/253
To address outdated database issue in POAM.

TODO: look at database outage during last upgrade