### PR TITLE
Update bucket lifecycle rules for latest terraform.

### DIFF
--- a/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
+++ b/terraform/modules/s3_bucket/encrypted_bucket/encrypted_bucket.tf
@@ -7,9 +7,12 @@ resource "aws_s3_bucket" "encrypted_bucket" {
 
     lifecycle_rule {
         prefix = ""
+        enabled = "${var.expiration_days == 0 ? "false" : "true"}"
         enabled = "${lookup(map("0", "false"), var.expiration_days, "true")}"
         expiration {
-            days = "${var.expiration_days}"
+            # Hack: Set expiration days to 30 if unset; objects won't actually be expired because the rule will be disabled
+            # See https://github.com/terraform-providers/terraform-provider-aws/issues/1402
+            days = "${var.expiration_days == 0 ? 30 : var.expiration_days}"
         }
     }
 


### PR DESCRIPTION
Goes with https://github.com/18F/cg-deploy-concourse-docker-image/pull/32.