### PR TITLE
use the VPC flow log Terraform module

### DIFF
--- a/terraform/modules/bosh_vpc/vpc.tf
+++ b/terraform/modules/bosh_vpc/vpc.tf
@@ -15,57 +15,10 @@ resource "aws_vpc" "main_vpc" {
 
 }
 
-# Create CloudWatch log group
-resource "aws_cloudwatch_log_group" "main_vpc_flow_log_cloudwatch_log_group" {
-  name = "${var.stack_description}-flow-log-group"
-}
+module "flow_logs" {
+  source = "github.com/GSA/terraform-vpc-flow-log"
 
-# Create IAM role for sending flow logs
-resource "aws_iam_role" "flow_log_role" {
-    name = "${var.stack_description}-flow-log-role"
-    assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "vpc-flow-logs.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy" "flow_log_policy" {
-    name = "${var.stack_description}-flow-log-policy"
-    role = "${aws_iam_role.flow_log_role.id}"
-    policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_flow_log" "main_vpc_flow_log" {
-  log_group_name = "${aws_cloudwatch_log_group.main_vpc_flow_log_cloudwatch_log_group.name}"
-  iam_role_arn = "${aws_iam_role.flow_log_role.arn}"
   vpc_id = "${aws_vpc.main_vpc.id}"
-  traffic_type = "ALL"
+  prefix = "${var.stack_description}"
+  log_group_name = "${var.stack_description}-flow-log-group"
 }


### PR DESCRIPTION
This reusable module was built as part of the DevSecOps effort, and we are looking for adoption and feedback. Rather than every project needing to include the same boilerplate code (for setting up the flow logs, in this case), hoping to get various projects at GSA to use reusable pieces like this one. Let me know what you think!

I `valididate`d the module locally, but don't have the ability to test it for real. Since the `aws_cloudwatch_log_group` changed modules, you will need to `terraform state mv` it to ensure the log group isn't destroyed and recreated.