### PR TITLE
wait for propagation of the instance profile

### DIFF
--- a/terraform/modules/iam_role/role.tf
+++ b/terraform/modules/iam_role/role.tf
@@ -7,6 +7,12 @@ resource "aws_iam_role" "iam_role" {
 resource "aws_iam_instance_profile" "iam_profile" {
   name = "${var.role_name}"
   role = "${aws_iam_role.iam_role.name}"
+  
+  # wait for propagation
+  # https://github.com/hashicorp/terraform/issues/2349#issuecomment-114168159
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
 }
 
 resource "aws_iam_role_policy" "iam_policy" {


### PR DESCRIPTION
It's a bit of a hack, but this will help with the gap between when the Instance Profile is created, and when it's actually usable. In leveraging this module, trying to use the Instance Profile immediately was giving an error of `Invalid IAM Instance Profile name`.

/cc @Vermyndax