### PR TITLE
Use built-in list types instead of splitting strings.

### DIFF
--- a/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
+++ b/terraform/modules/bosh_vpc/sg_restricted_web_traffic.tf
@@ -14,14 +14,14 @@ resource "aws_security_group" "restricted_web_traffic" {
     from_port = 80
     to_port = 80
     protocol = "tcp"
-    cidr_blocks = ["${split(",", var.restricted_ingress_web_cidrs)}"]
+    cidr_blocks = ["${var.restricted_ingress_web_cidrs}"]
   }
 
   ingress {
     from_port = 443
     to_port = 443
     protocol = "tcp"
-    cidr_blocks = ["${split(",", var.restricted_ingress_web_cidrs)}"]
+    cidr_blocks = ["${var.restricted_ingress_web_cidrs}"]
   }
 
   egress {

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -33,7 +33,8 @@ variable "private_cidr_2" {
 }
 
 variable "restricted_ingress_web_cidrs" {
-  default = "127.0.0.1/32,192.168.0.1/24"
+  type = "list"
+  default = ["127.0.0.1/32", "192.168.0.1/24"]
 }
 
 variable "nat_gateway_instance_type" {

--- a/terraform/modules/client-elbs/star_18f_gov_elb.tf
+++ b/terraform/modules/client-elbs/star_18f_gov_elb.tf
@@ -2,8 +2,8 @@ resource "aws_elb" "star_18f_gov_elb" {
   count = "${var.count}"
 
   name = "${var.stack_description}-star-18f-gov-elb"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
 
   listener {
     lb_port = 80

--- a/terraform/modules/client-elbs/variables.tf
+++ b/terraform/modules/client-elbs/variables.tf
@@ -2,9 +2,13 @@ variable "star_18f_gov_cert_name" {}
 
 variable "count" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 
-variable "elb_security_groups" {}
+variable "elb_security_groups" {
+  type = "list"
+}
 
 variable "stack_description" {}
 

--- a/terraform/modules/cloudfoundry/database.tf
+++ b/terraform/modules/cloudfoundry/database.tf
@@ -10,5 +10,5 @@ module "cf_database_96" {
     rds_username = "${var.rds_username}"
     rds_password = "${var.rds_password}"
     rds_subnet_group = "${var.rds_subnet_group}"
-    rds_security_groups = "${var.rds_security_groups}"
+    rds_security_groups = ["${var.rds_security_groups}"]
 }

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "cloudfoundry_elb_apps" {
   name = "${var.stack_description}-CloudFoundry-Apps"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
 
   listener {
     lb_port = 80

--- a/terraform/modules/cloudfoundry/elb_logging.tf
+++ b/terraform/modules/cloudfoundry/elb_logging.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "cloudfoundry_elb_logging" {
   name = "${var.stack_description}-CloudFoundry-Logging"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
 
   listener {
     lb_port = 443

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "cloudfoundry_elb_main" {
   name = "${var.stack_description}-CloudFoundry-Main"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
 
   listener {
     lb_port = 80

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -2,9 +2,13 @@ variable "elb_main_cert_name" {}
 
 variable "elb_apps_cert_name" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 
-variable "elb_security_groups" {}
+variable "elb_security_groups" {
+  type = "list"
+}
 
 variable "stack_description" {}
 
@@ -38,7 +42,9 @@ variable "rds_password" {}
 
 variable "rds_subnet_group" {}
 
-variable "rds_security_groups" {}
+variable "rds_security_groups" {
+  type = "list"
+}
 
 variable "stack_prefix" {}
 

--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "concourse_elb" {
   name = "${replace("${var.stack_description}-Concourse-${var.concourse_az}", "/(.{0,32})(.*)/", "$1")}"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
   idle_timeout = 3600
 
   listener {

--- a/terraform/modules/concourse/rds.tf
+++ b/terraform/modules/concourse/rds.tf
@@ -11,6 +11,6 @@ module "rds_96" {
   rds_username = "${var.rds_username}"
   rds_password = "${var.rds_password}"
   rds_subnet_group = "${var.rds_subnet_group}"
-  rds_security_groups = "${var.rds_security_groups}"
+  rds_security_groups = ["${var.rds_security_groups}"]
   rds_parameter_group_name = "${var.rds_parameter_group_name}"
 }

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -44,7 +44,9 @@ variable "rds_password" {}
 
 variable "rds_subnet_group" {}
 
-variable "rds_security_groups" {}
+variable "rds_security_groups" {
+  type = "list"
+}
 
 variable "route_table_id" {}
 
@@ -54,8 +56,12 @@ variable "account_id" {}
 
 variable "elb_cert_name" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 
-variable "elb_security_groups" {}
+variable "elb_security_groups" {
+  type = "list"
+}
 
 variable "aws_partition" {}

--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -16,7 +16,7 @@ resource "aws_security_group" "diego-elb-sg" {
     from_port = 2222
     to_port = 2222
     protocol = "tcp"
-    cidr_blocks = ["${split(",", var.ingress_cidrs)}"]
+    cidr_blocks = ["${var.ingress_cidrs}"]
   }
 
   # 22 / 443 are alternate ports available for manually use by customers with restrictive firewalls
@@ -24,14 +24,14 @@ resource "aws_security_group" "diego-elb-sg" {
     from_port = 22
     to_port = 22
     protocol = "tcp"
-    cidr_blocks = ["${split(",", var.ingress_cidrs)}"]
+    cidr_blocks = ["${var.ingress_cidrs}"]
   }
 
   ingress {
     from_port = 443
     to_port = 443
     protocol = "tcp"
-    cidr_blocks = ["${split(",", var.ingress_cidrs)}"]
+    cidr_blocks = ["${var.ingress_cidrs}"]
   }
 
   # outbound internet access
@@ -46,7 +46,7 @@ resource "aws_security_group" "diego-elb-sg" {
 
 resource "aws_elb" "diego_elb_main" {
   name = "${var.stack_description}-diego-proxy"
-  subnets = ["${split(",", var.elb_subnets)}"]
+  subnets = ["${var.elb_subnets}"]
   security_groups = ["${aws_security_group.diego-elb-sg.id}"]
 
   listener {

--- a/terraform/modules/diego/variables.tf
+++ b/terraform/modules/diego/variables.tf
@@ -14,12 +14,15 @@ variable "private_route_table_az2" {}
 
 variable "vpc_id" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 
 variable "diego_cidr_1" {}
 
 variable "diego_cidr_2" {}
 
 variable "ingress_cidrs" {
-  default = "0.0.0.0"
+  type = "list"
+  default = ["0.0.0.0"]
 }

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -1,6 +1,6 @@
 resource "aws_elb" "kubernetes_elb" {
   name = "${var.stack_description}-kubernetes"
-  subnets = ["${split(",", var.elb_subnets)}"]
+  subnets = ["${var.elb_subnets}"]
   security_groups = ["${aws_security_group.kubernetes_elb.id}"]
   idle_timeout = 3600
   internal = true

--- a/terraform/modules/kubernetes/variables.tf
+++ b/terraform/modules/kubernetes/variables.tf
@@ -4,7 +4,9 @@ variable "aws_default_region" {}
 variable "vpc_id" {}
 variable "vpc_cidr" {}
 variable "tooling_vpc_cidr" {}
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 variable "target_bosh_security_group" {}
 variable "target_monitoring_security_group" {}
 variable "target_concourse_security_group" {}

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -1,7 +1,7 @@
 resource "aws_elb" "monitoring_elb" {
   name = "${var.stack_description}-Monitoring"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
   idle_timeout = 3600
 
   listener {
@@ -27,8 +27,8 @@ resource "aws_elb" "monitoring_elb" {
 
 resource "aws_elb" "prometheus_elb" {
   name = "${var.stack_description}-Prometheus"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.prometheus_elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.prometheus_elb_security_groups}"]
   idle_timeout = 3600
 
   listener {

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -16,9 +16,13 @@ variable "account_id" {}
 
 variable "elb_cert_name" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
 
-variable "elb_security_groups" {}
+variable "elb_security_groups" {
+  type = "list"
+}
 
 variable "prometheus_elb_security_groups" {}
 

--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "rds_database" {
   storage_encrypted = true
 
   db_subnet_group_name = "${var.rds_subnet_group}"
-  vpc_security_group_ids = ["${split(",", var.rds_security_groups)}"]
+  vpc_security_group_ids = ["${var.rds_security_groups}"]
   parameter_group_name = "${var.rds_db_engine == "postgres" ?
     "${join("", aws_db_parameter_group.parameter_group_postgres.*.id)}" :
     "${join("", aws_db_parameter_group.parameter_group_mysql.*.id)}"}"

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -32,7 +32,9 @@ variable "rds_password" {}
 
 variable "rds_subnet_group" {}
 
-variable "rds_security_groups" {}
+variable "rds_security_groups" {
+  type = "list"
+}
 
 variable "rds_parameter_group_name" {
   default = ""

--- a/terraform/modules/shibboleth/shibboleth_elb_main.tf
+++ b/terraform/modules/shibboleth/shibboleth_elb_main.tf
@@ -11,8 +11,8 @@
 
 resource "aws_elb" "shibboleth_elb_main" {
   name = "${var.stack_description}-shibboleth-proxy"
-  subnets = ["${split(",", var.elb_subnets)}"]
-  security_groups = ["${split(",", var.elb_security_groups)}"]
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
 
   listener {
     lb_port = 443

--- a/terraform/modules/shibboleth/variables.tf
+++ b/terraform/modules/shibboleth/variables.tf
@@ -1,11 +1,15 @@
 variable "stack_description" {}
 
-variable "elb_subnets" {}
+variable "elb_subnets" {
+  type = "list"
+}
+
+variable "elb_security_groups" {
+  type = "list"
+}
 
 variable "elb_shibboleth_cert_name" {}
 
 variable "account_id" {}
 
 variable "aws_partition" {}
-
-variable "elb_security_groups" {}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -45,5 +45,5 @@ module "rds" {
   rds_username = "${var.rds_username}"
   rds_password = "${var.rds_password}"
   rds_subnet_group = "${module.rds_network.rds_subnet_group}"
-  rds_security_groups = "${module.rds_network.rds_postgres_security_group}"
+  rds_security_groups = ["${module.rds_network.rds_postgres_security_group}"]
 }

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -71,7 +71,8 @@ variable "rds_username" {
 variable "rds_password" {}
 
 variable "restricted_ingress_web_cidrs" {
-    default = "127.0.0.1/32,192.168.0.1/24"
+  type = "list"
+  default = ["127.0.0.1/32","192.168.0.1/24"]
 }
 
 variable "rds_security_groups" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -69,7 +69,8 @@ variable "rds_username" {
 }
 
 variable "restricted_ingress_web_cidrs" {
-    default = "127.0.0.1/32,192.168.0.1/24"
+  type = "list"
+  default = ["127.0.0.1/32","192.168.0.1/24"]
 }
 
 variable "aws_partition" {}

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -42,7 +42,9 @@ variable "services_cidr_1" {}
 variable "services_cidr_2" {}
 variable "kubernetes_cluster_id" {}
 
-variable "restricted_ingress_web_cidrs" {}
+variable "restricted_ingress_web_cidrs" {
+  type = "list"
+}
 
 variable "18f_gov_elb_cert_name" {
   default = ""

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -39,13 +39,13 @@ module "concourse_production" {
   route_table_id = "${module.stack.private_route_table_az1}"
   rds_password = "${var.concourse_prod_rds_password}"
   rds_subnet_group = "${module.stack.rds_subnet_group}"
-  rds_security_groups = "${module.stack.rds_postgres_security_group}"
+  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
   rds_parameter_group_name = "tooling-concourse-production"
   rds_instance_type = "db.m3.xlarge"
   account_id = "${var.account_id}"
   elb_cert_name = "${var.concourse_prod_elb_cert_name}"
-  elb_subnets = "${module.stack.public_subnet_az1}"
-  elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
+  elb_subnets = ["${module.stack.public_subnet_az1}"]
+  elb_security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
 }
 
 module "concourse_staging" {
@@ -58,13 +58,13 @@ module "concourse_staging" {
   route_table_id = "${module.stack.private_route_table_az2}"
   rds_password = "${var.concourse_staging_rds_password}"
   rds_subnet_group = "${module.stack.rds_subnet_group}"
-  rds_security_groups = "${module.stack.rds_postgres_security_group}"
+  rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
   rds_parameter_group_name = "tooling-concourse-staging"
   rds_instance_type = "db.m3.medium"
   account_id = "${var.account_id}"
   elb_cert_name = "${var.concourse_staging_elb_cert_name}"
-  elb_subnets = "${module.stack.public_subnet_az2}"
-  elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
+  elb_subnets = ["${module.stack.public_subnet_az2}"]
+  elb_security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
 }
 
 module "monitoring_production" {
@@ -77,8 +77,8 @@ module "monitoring_production" {
   route_table_id = "${module.stack.private_route_table_az1}"
   account_id = "${var.account_id}"
   elb_cert_name = "${var.monitoring_production_elb_cert_name}"
-  elb_subnets = "${module.stack.public_subnet_az1}"
-  elb_security_groups = "${module.stack.web_traffic_security_group}"
+  elb_subnets = ["${module.stack.public_subnet_az1}"]
+  elb_security_groups = ["${module.stack.web_traffic_security_group}"]
   prometheus_elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
 }
 
@@ -92,8 +92,8 @@ module "monitoring_staging" {
   route_table_id = "${module.stack.private_route_table_az2}"
   account_id = "${var.account_id}"
   elb_cert_name = "${var.monitoring_staging_elb_cert_name}"
-  elb_subnets = "${module.stack.public_subnet_az2}"
-  elb_security_groups = "${module.stack.web_traffic_security_group}"
+  elb_subnets = ["${module.stack.public_subnet_az2}"]
+  elb_security_groups = ["${module.stack.web_traffic_security_group}"]
   prometheus_elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
 }
 

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -67,6 +67,8 @@ variable "bosh_uaa_elb_cert_name" {
     default = "star-fr-cloud-gov-2017-05"
 }
 
-variable "restricted_ingress_web_cidrs" {}
+variable "restricted_ingress_web_cidrs" {
+  type = "list"
+}
 
 variable "blobstore_bucket_name" {}


### PR DESCRIPTION
Now that HCL mostly supports list variables, we don't have to split strings anymore. I pointed our pipeline at this branch and verified that nothing will change in any of our environments.