### PR TITLE
Drop unnecessary count hack.

### DIFF
--- a/terraform/modules/bosh_vpc/sg_bosh.tf
+++ b/terraform/modules/bosh_vpc/sg_bosh.tf
@@ -115,12 +115,12 @@ resource "aws_security_group_rule" "bosh_director" {
 }
 
 resource "aws_security_group_rule" "node_exporter" {
-    count = "${var.monitoring_security_group_count}"
+    count = "${length(var.monitoring_security_groups)}"
     type = "ingress"
     from_port = 9100
     to_port = 9100
     protocol = "tcp"
-    source_security_group_id = "${var.monitoring_security_group}"
+    source_security_group_id = "${element(var.monitoring_security_groups, count.index)}"
     security_group_id = "${aws_security_group.bosh.id}"
 }
 
@@ -134,17 +134,17 @@ resource "aws_security_group_rule" "platform_kibana" {
 }
 
 resource "aws_security_group_rule" "monitoring_elasticsearch_exporter" {
-    count = "${var.monitoring_security_group_count}"
+    count = "${length(var.monitoring_security_groups)}"
     type = "ingress"
     from_port = 9114
     to_port = 9114
     protocol = "tcp"
-    source_security_group_id = "${var.monitoring_security_group}"
+    source_security_group_id = "${element(var.monitoring_security_groups, count.index)}"
     security_group_id = "${aws_security_group.bosh.id}"
 }
 
 resource "aws_security_group_rule" "concourse_logsearch" {
-    count = "${var.concourse_security_group_count}"
+    count = "${length(var.concourse_security_groups)}"
     type = "ingress"
     from_port = 9200
     to_port = 9200
@@ -154,7 +154,7 @@ resource "aws_security_group_rule" "concourse_logsearch" {
 }
 
 resource "aws_security_group_rule" "concourse_secureproxy" {
-    count = "${var.concourse_security_group_count}"
+    count = "${length(var.concourse_security_groups)}"
     type = "ingress"
     from_port = 80
     to_port = 80

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -41,19 +41,14 @@ variable "nat_gateway_instance_type" {
   default = "c3.2xlarge"
 }
 
-variable "monitoring_security_group" {
-  default = ""
-}
-variable "monitoring_security_group_count" {
-  default = 0
+variable "monitoring_security_groups" {
+  type = "list"
+  default = []
 }
 
 variable "concourse_security_groups" {
   type = "list"
   default = []
-}
-variable "concourse_security_group_count" {
-  default = "0"
 }
 
 variable "use_nat_gateway_eip" {

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -12,10 +12,8 @@ module "vpc" {
     public_cidr_2 = "${var.public_cidr_2}"
     restricted_ingress_web_cidrs = "${var.restricted_ingress_web_cidrs}"
     nat_gateway_instance_type = "${var.nat_gateway_instance_type}"
-    monitoring_security_group = "${var.target_monitoring_security_group}"
-    monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    monitoring_security_groups = "${var.target_monitoring_security_groups}"
     concourse_security_groups = "${var.target_concourse_security_groups}"
-    concourse_security_group_count = "${var.target_concourse_security_group_count}"
     use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
 }
 

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -79,19 +79,14 @@ variable "rds_security_groups" {
   type = "list"
 }
 
-variable "target_monitoring_security_group" {
-  default = ""
-}
-variable "target_monitoring_security_group_count" {
-  default = 0
+variable "target_monitoring_security_groups" {
+  type = "list"
+  default = []
 }
 
 variable "target_concourse_security_groups" {
   type = "list"
   default = []
-}
-variable "target_concourse_security_group_count" {
-  default = "0"
 }
 
 variable "use_nat_gateway_eip" {

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -24,10 +24,8 @@ module "base" {
       "${module.base.bosh_security_group}",
       "${var.target_bosh_security_group}"
     ]
-    target_monitoring_security_group = "${var.target_monitoring_security_group}"
-    target_monitoring_security_group_count = "${var.target_monitoring_security_group_count}"
+    target_monitoring_security_groups = "${var.target_monitoring_security_groups}"
     target_concourse_security_groups = "${var.target_concourse_security_groups}"
-    target_concourse_security_group_count = "${var.target_concourse_security_group_count}"
     use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
 }
 

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -85,19 +85,14 @@ variable "target_bosh_security_group" {}
 variable "target_az1_route_table" {}
 variable "target_az2_route_table" {}
 
-variable "target_monitoring_security_group" {
-  default = ""
-}
-variable "target_monitoring_security_group_count" {
-  default = 0
+variable "target_monitoring_security_groups" {
+  type = "list"
+  default = []
 }
 
 variable "target_concourse_security_groups" {
   type = "list"
   default = []
-}
-variable "target_concourse_security_group_count" {
-  default = "0"
 }
 variable "use_nat_gateway_eip" {
   default = false

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -32,13 +32,13 @@ module "stack" {
     target_bosh_security_group = "${data.terraform_remote_state.target_vpc.bosh_security_group}"
     target_az1_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az1}"
     target_az2_route_table = "${data.terraform_remote_state.target_vpc.private_route_table_az2}"
-    target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
-    target_monitoring_security_group_count = 1
+    target_monitoring_security_groups = [
+      "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
+    ]
     target_concourse_security_groups = [
       "${data.terraform_remote_state.target_vpc.production_concourse_security_group}",
       "${data.terraform_remote_state.target_vpc.staging_concourse_security_group}"
     ]
-    target_concourse_security_group_count = 2
     use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
 }
 


### PR DESCRIPTION
It looks like terraform fixed a limitation around using `count` with list variables, so we can drop the terrible hack of passing around a list along with a separate count variable. I confirmed that no plans change after applying this patch.