### PR TITLE
Use consistent output names for *.18f.gov elb.

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -302,11 +302,11 @@ output "platform_kibana_elb_dns_name" {
 }
 
 /* Client ELBs */
-output "client_elb_star_18f_gov_name" {
+output "star_18f_gov_elb_name" {
   value = "${module.client-elbs.star_18f_gov_elb_name}"
 }
 
-output "client_elb_star_18f_gov_dns_name" {
+output "star_18f_gov_elb_dns_name" {
   value = "${module.client-elbs.star_18f_gov_elb_dns_name}"
 }
 


### PR DESCRIPTION
Part of restoring *.18f.gov after cf-deployment migration.