### PR TITLE
Add dns security group.

### DIFF
--- a/terraform/modules/dns/outputs.tf
+++ b/terraform/modules/dns/outputs.tf
@@ -1,0 +1,3 @@
+output "security_group" {
+  value = "${aws_security_group.dns.id}"
+}

--- a/terraform/modules/dns/sg.tf
+++ b/terraform/modules/dns/sg.tf
@@ -1,0 +1,22 @@
+resource "aws_security_group" "dns" {
+  description = "Allow access to incoming DNS traffic"
+  vpc_id = "${var.vpc_id}"
+
+  ingress {
+    self = true
+    from_port = 53
+    to_port = 53
+    protocol = "-1"
+  }
+
+  egress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.stack_description} - Incoming DNS Traffic"
+  }
+}

--- a/terraform/modules/dns/variables.tf
+++ b/terraform/modules/dns/variables.tf
@@ -1,0 +1,2 @@
+variable "stack_description" {}
+variable "vpc_id" {}

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -384,6 +384,10 @@ output "staging_dns_public_ips" {
   value = ["${aws_eip.staging_dns_eip.*.public_ip}"]
 }
 
+output "dns_security_group" {
+  value = "${module.dns.security_group}"
+}
+
 output "staging_dns_private_ips" {
   value = [
     "${cidrhost("${var.private_cidr_1}", 8)}",

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -217,6 +217,12 @@ resource "aws_eip" "staging_dns_eip" {
   }
 }
 
+module "dns" {
+  source = "../../modules/dns"
+  stack_description = "${var.stack_description}"
+  vpc_id = "${module.stack.vpc_id}"
+}
+
 resource "aws_iam_policy_attachment" "blobstore" {
   name = "${var.stack_description}-blobstore"
   policy_arn = "${module.blobstore_policy.arn}"


### PR DESCRIPTION
Allow public and private dns servers to communicate over port 53.