### PR TITLE
Export public subnet cidrs.

### DIFF
--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -111,6 +111,13 @@ output "public_subnet_az1" {
 output "public_subnet_az2" {
   value = "${module.stack.public_subnet_az2}"
 }
+output "public_subnet_az1_cidr" {
+  value = "${var.public_cidr_1}"
+}
+output "public_subnet_az2_cidr" {
+  value = "${var.public_cidr_2}"
+}
+
 output "public_route_table" {
   value = "${module.stack.public_route_table}"
 }


### PR DESCRIPTION
For consumption by downstream deployments.