### PR TITLE
Enable versioning for buildpack notify state.

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -113,12 +113,14 @@ module "buildpack_notify_state_staging" {
   source = "../../modules/s3_bucket/encrypted_bucket"
   bucket = "buildpack-notify-state-staging"
   aws_partition = "${var.aws_partition}"
+  versioning = "true"
 }
 
 module "buildpack_notify_state_production" {
   source = "../../modules/s3_bucket/encrypted_bucket"
   bucket = "buildpack-notify-state-production"
   aws_partition = "${var.aws_partition}"
+  versioning = "true"
 }
 
 module "cg_binaries_bucket" {


### PR DESCRIPTION
So that we can easily use state files via concourse resources.