### PR TITLE
Pin provider versions.

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -1,18 +1,3 @@
-/*
- * Variables required:
- *  stack_description
- *  rds_db_engine
- *  rds_db_engine_version
- *  rds_db_name
- *  rds_db_size
- *  rds_db_storage_type
- *  rds_instance_type
- *  rds_username
- *  rds_password
- *  rds_subnet_group
- *  rds_security_groups
- */
-
 resource "aws_db_instance" "rds_database" {
   engine               = "${var.rds_db_engine}"
   engine_version       = "${var.rds_db_engine_version}"

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -2,6 +2,10 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  version = "~> 1.8.0"
+}
+
 variable "cloudfront_zone_id" {
   default = "Z33AYJ8TM3BH4J"
 }

--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -2,6 +2,10 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  version = "~> 1.8.0"
+}
+
 module "cdn_broker" {
   source = "../../modules/cdn_broker"
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -2,6 +2,10 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  version = "~> 1.8.0"
+}
+
 data "terraform_remote_state" "target_vpc" {
   backend = "s3"
   config {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -1,13 +1,9 @@
-/*
- * Tooling stack
- *
- * This stack relies on defaults heavily. Please look through
- * all the module sources, and specifically, the variables.tf
- * in each module, which declares these defaults.
- */
-
 terraform {
   backend "s3" {}
+}
+
+provider "aws" {
+  version = "~> 1.8.0"
 }
 
 module "stack" {


### PR DESCRIPTION
As recommended by terraform warnings. This also keeps us from upgrading to aws provider 1.9.x, which includes a semi-breaking change around vpc endpoints.