### PR TITLE
make sure shell output doesn't have AWS variables

### DIFF
--- a/ci/check-certificates.sh
+++ b/ci/check-certificates.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 export AWS_ACCESS_KEY_ID=$(spruce json terraform-yaml-tooling/state.yml | jq -r ".terraform_outputs.iam_cert_provision_access_key_id_curr")
 export AWS_SECRET_ACCESS_KEY=$(spruce json terraform-yaml-tooling/state.yml | jq -r ".terraform_outputs.iam_cert_provision_secret_access_key_curr")

--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 curl -L -o jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
 chmod +x ./jq

--- a/ci/upload-certificate.sh
+++ b/ci/upload-certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eux
+set -eu
 
 if [ -s acme/cert.pem ]; then
   export AWS_ACCESS_KEY_ID=$(spruce json terraform-yaml-tooling/state.yml | jq -r ".terraform_outputs.iam_cert_provision_access_key_id_curr")


### PR DESCRIPTION
seems bad to have this in the logs.