### PR TITLE
[WIP] Add ALBs alongside ELBs.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -305,6 +305,10 @@ jobs:
       TF_VAR_blobstore_bucket_name: bosh-development-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "false"
+      TF_VAR_use_apps_certificate: "false"
+      TF_VAR_cf_hosts: '["*.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
+      TF_VAR_shibboleth_hosts: '["idp.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
+      TF_VAR_platform_kibana_hosts: '["logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
   - *notify-slack
 
 - name: bootstrap-development
@@ -414,6 +418,9 @@ jobs:
       TF_VAR_blobstore_bucket_name: bosh-staging-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "true"
+      TF_VAR_cf_hosts: '["*.fr-stage.cloud.gov"]'
+      TF_VAR_shibboleth_hosts: '["idp.fr-stage.cloud.gov"]'
+      TF_VAR_platform_kibana_hosts: '["logs-platform.fr-stage.cloud.gov"]'
   - *notify-slack
 
 - name: bootstrap-staging
@@ -523,6 +530,9 @@ jobs:
       TF_VAR_blobstore_bucket_name: bosh-prod-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "true"
+      TF_VAR_cf_hosts: '["*.fr.cloud.gov", "*.app.cloud.gov", "*.18f.gov"]'
+      TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
+      TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
   - *notify-slack
 
 - name: bootstrap-production

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -207,6 +207,14 @@ jobs:
       TF_VAR_rds_private_cidr_2: ((tooling_rds_private_cidr_2))
       TF_VAR_restricted_ingress_web_cidrs: ((tooling_restricted_ingress_web_cidrs))
       TF_VAR_blobstore_bucket_name: bosh-tooling-blobstore
+      TF_VAR_concourse_production_hosts: '["ci.fr.cloud.gov"]'
+      TF_VAR_concourse_staging_hosts: '["ci.fr-stage.cloud.gov"]'
+      TF_VAR_monitoring_production_hosts: '["prometheus.fr.cloud.gov", "alertmanager.fr.cloud.gov", "grafana.fr.cloud.gov"]'
+      TF_VAR_monitoring_staging_hosts: '["prometheus.fr-stage.cloud.gov", "alertmanager.fr-stage.cloud.gov", "grafana.fr-stage.cloud.gov"]'
+      TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
+      TF_VAR_main_cert_name: star-fr-cloud-gov-2017-05
+      TF_VAR_staging_cert_name: star-fr-stage-cloud-gov-2017-05
+      TF_VAR_use_staging_certificate: "true"
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -31,3 +31,53 @@ resource "aws_elb" "cloudfoundry_elb_main" {
     Name = "${var.stack_description}-CloudFoundry-Main"
   }
 }
+
+resource "aws_lb_target_group" "cf_target" {
+  name     = "${var.stack_description}-cf"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 5
+    port = 81
+    timeout = 4
+    unhealthy_threshold = 3
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener_rule" "cf" {
+  count = "${length(var.hosts)}"
+
+  listener_arn = "${var.listener_arn}"
+  priority = 1000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.cf_target.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${element(var.hosts, count.index)}"]
+  }
+}
+
+resource "aws_lb_listener_rule" "cf_http" {
+  count = "${length(var.hosts)}"
+
+  listener_arn = "${var.http_listener_arn}"
+  priority = 1000
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.cf_target.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${element(var.hosts, count.index)}"]
+  }
+}

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -22,6 +22,10 @@ output "elb_apps_name" {
   value = "${aws_elb.cloudfoundry_elb_apps.name}"
 }
 
+output "lb_target_group" {
+  value = "${aws_lb_target_group.cf_target.name}"
+}
+
 output "cf_rds_url" {
   value = "${module.cf_database_96.rds_url}"
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -73,3 +73,9 @@ variable "aws_partition" {}
 variable "kubernetes_cluster_id" {}
 
 variable "bucket_prefix" {}
+
+variable "listener_arn" {}
+variable "http_listener_arn" {}
+variable "hosts" {
+  type = "list"
+}

--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -20,7 +20,38 @@ resource "aws_elb" "concourse_elb" {
     interval = 30
   }
 
-  tags =  {
+  tags {
     Name = "${var.stack_description}-Concourse-${var.concourse_az}"
+  }
+}
+
+resource "aws_lb_target_group" "concourse_target" {
+  name     = "${var.stack_description}-concourse-${var.concourse_az}"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    unhealthy_threshold = 10
+    timeout = 5
+    interval = 30
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener_rule" "concourse_listener_rule" {
+  count = "${length(var.hosts)}"
+
+  listener_arn = "${var.listener_arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.concourse_target.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${element(var.hosts, count.index)}"]
   }
 }

--- a/terraform/modules/concourse/outputs.tf
+++ b/terraform/modules/concourse/outputs.tf
@@ -49,3 +49,7 @@ output "concourse_elb_name" {
 output "concourse_elb_zone_id" {
   value = "${aws_elb.concourse_elb.zone_id}"
 }
+
+output "concourse_lb_target_group" {
+  value = "${aws_lb_target_group.concourse_target.name}"
+}

--- a/terraform/modules/concourse/variables.tf
+++ b/terraform/modules/concourse/variables.tf
@@ -65,3 +65,9 @@ variable "elb_subnets" {
 variable "elb_security_groups" {
   type = "list"
 }
+
+variable "listener_arn" {}
+
+variable "hosts" {
+  type = "list"
+}

--- a/terraform/modules/logsearch/outputs.tf
+++ b/terraform/modules/logsearch/outputs.tf
@@ -19,3 +19,13 @@ output "platform_kibana_elb_name" {
 output "platform_kibana_elb_dns_name" {
   value = "${aws_elb.platform_kibana_elb.dns_name}"
 }
+
+output "platform_kibana_lb_name" {
+  value = "${aws_lb.platform_kibana_lb.name}"
+}
+output "platform_kibana_lb_dns_name" {
+  value = "${aws_lb.platform_kibana_lb.dns_name}"
+}
+output "platform_kibana_lb_target_group" {
+  value = "${aws_lb_target_group.platform_kibana_target.name}"
+}

--- a/terraform/modules/logsearch/outputs.tf
+++ b/terraform/modules/logsearch/outputs.tf
@@ -20,12 +20,6 @@ output "platform_kibana_elb_dns_name" {
   value = "${aws_elb.platform_kibana_elb.dns_name}"
 }
 
-output "platform_kibana_lb_name" {
-  value = "${aws_lb.platform_kibana_lb.name}"
-}
-output "platform_kibana_lb_dns_name" {
-  value = "${aws_lb.platform_kibana_lb.dns_name}"
-}
 output "platform_kibana_lb_target_group" {
-  value = "${aws_lb_target_group.platform_kibana_target.name}"
+  value = "${aws_lb_target_group.platform_kibana.name}"
 }

--- a/terraform/modules/logsearch/variables.tf
+++ b/terraform/modules/logsearch/variables.tf
@@ -5,3 +5,7 @@ variable "private_elb_subnets" {type = "list"}
 variable "bosh_security_group" {}
 variable "restricted_security_group" {}
 variable "elb_cert_id" {}
+variable "listener_arn" {}
+variable "hosts" {
+  type = "list"
+}

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -24,3 +24,35 @@ resource "aws_elb" "prometheus_elb" {
     Name = "${var.stack_description}-Prometheus"
   }
 }
+
+resource "aws_lb_target_group" "prometheus_target" {
+  name     = "${var.stack_description}-prometheus"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 5
+    path = "/ping"
+    timeout = 4
+    unhealthy_threshold = 3
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener_rule" "prometheus_listener_rule" {
+  count = "${length(var.hosts)}"
+
+  listener_arn = "${var.listener_arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.prometheus_target.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${element(var.hosts, count.index)}"]
+  }
+}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -17,3 +17,7 @@ output "prometheus_elb_dns_name" {
 output "prometheus_elb_name" {
   value = "${aws_elb.prometheus_elb.name}"
 }
+
+output "lb_target_group" {
+  value = "${aws_lb_target_group.prometheus_target.name}"
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -21,3 +21,9 @@ variable "elb_subnets" {
 variable "elb_security_groups" {}
 
 variable "prometheus_elb_security_groups" {}
+
+variable "listener_arn" {}
+
+variable "hosts" {
+  type = "list"
+}

--- a/terraform/modules/shibboleth/outputs.tf
+++ b/terraform/modules/shibboleth/outputs.tf
@@ -12,16 +12,6 @@ output "shibboleth_elb_zone_id" {
   value = "${aws_elb.shibboleth_elb_main.zone_id}"
 }
 
-/* shibboleth Proxy LB */
-
-output "shibboleth_lb_name" {
-  value = "${aws_lb.shibboleth_lb.name}"
-}
-
-output "shibboleth_lb_dns_name" {
-  value = "${aws_lb.shibboleth_lb.dns_name}"
-}
-
 output "shibboleth_lb_target_group" {
-  value = "${aws_lb_target_group.shibboleth_target.name}"
+  value = "${aws_lb_target_group.shibboleth.name}"
 }

--- a/terraform/modules/shibboleth/outputs.tf
+++ b/terraform/modules/shibboleth/outputs.tf
@@ -1,4 +1,3 @@
-
 /* shibboleth Proxy ELB */
 
 output "shibboleth_elb_name" {
@@ -11,4 +10,18 @@ output "shibboleth_elb_dns_name" {
 
 output "shibboleth_elb_zone_id" {
   value = "${aws_elb.shibboleth_elb_main.zone_id}"
+}
+
+/* shibboleth Proxy LB */
+
+output "shibboleth_lb_name" {
+  value = "${aws_lb.shibboleth_lb.name}"
+}
+
+output "shibboleth_lb_dns_name" {
+  value = "${aws_lb.shibboleth_lb.dns_name}"
+}
+
+output "shibboleth_lb_target_group" {
+  value = "${aws_lb_target_group.shibboleth_target.name}"
 }

--- a/terraform/modules/shibboleth/shibboleth_elb_main.tf
+++ b/terraform/modules/shibboleth/shibboleth_elb_main.tf
@@ -37,9 +37,55 @@ resource "aws_elb" "shibboleth_elb_main" {
 
 }
 
-resource "aws_app_cookie_stickiness_policy" "shibboleth_jsession_stickiness" {
+resource "aws_app_cookie_stickiness_policy" "shibboleth_jsession_stickiness_legacy" {
   name = "${var.stack_description}-shibboleth-sticky-jsession"
   load_balancer = "${aws_elb.shibboleth_elb_main.name}"
-  lb_port = 443
   cookie_name = "JSESSIONID"
+  lb_port = 443
+}
+
+resource "aws_lb" "shibboleth_lb" {
+  name = "${var.stack_description}-shibboleth-proxy"
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
+
+  tags {
+    Name = "${var.stack_description}-shibboleth-Proxy-ELB"
+  }
+}
+
+resource "aws_lb_target_group" "shibboleth_target" {
+  name     = "${var.stack_description}-shibboleth"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 15
+    path = "/shibboleth"
+    timeout = 10
+    unhealthy_threshold = 2
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener" "shibboleth_listener" {
+  load_balancer_arn = "${aws_lb.shibboleth_lb.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${var.elb_shibboleth_cert_id}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.shibboleth_target.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_app_cookie_stickiness_policy" "shibboleth_jsession_stickiness" {
+  name = "${var.stack_description}-shibboleth-sticky-jsession"
+  load_balancer = "${aws_lb.shibboleth_lb.name}"
+  cookie_name = "JSESSIONID"
+  lb_port = 443
 }

--- a/terraform/modules/shibboleth/variables.tf
+++ b/terraform/modules/shibboleth/variables.tf
@@ -1,5 +1,7 @@
 variable "stack_description" {}
 
+variable "vpc_id" {}
+
 variable "elb_subnets" {
   type = "list"
 }

--- a/terraform/modules/shibboleth/variables.tf
+++ b/terraform/modules/shibboleth/variables.tf
@@ -11,3 +11,8 @@ variable "elb_security_groups" {
 }
 
 variable "elb_shibboleth_cert_id" {}
+
+variable "listener_arn" {}
+variable "hosts" {
+  type = "list"
+}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -144,6 +144,13 @@ output "kubernetes_static_ips" {
   value = ["${data.template_file.kubernetes_static_ips.*.rendered}"]
 }
 
+/* Main LB */
+output "main_lb_name" {
+  value = "${aws_lb.main.name}"
+}
+output "main_lb_dns_name" {
+  value = "${aws_lb.main.dns_name}"
+}
 
 /* Security Groups */
 output "bosh_security_group" {
@@ -253,6 +260,9 @@ output "cf_apps_elb_dns_name" {
 output "cf_apps_elb_name" {
   value = "${module.cf.elb_apps_name}"
 }
+output "cf_target_group" {
+  value = "${module.cf.lb_target_group}"
+}
 
 /* CloudFoundry RDS */
 output "cf_rds_url" {
@@ -319,12 +329,6 @@ output "platform_kibana_elb_dns_name" {
   value = "${module.logsearch.platform_kibana_elb_dns_name}"
 }
 
-output "platform_kibana_lb_name" {
-  value = "${module.logsearch.platform_kibana_lb_name}"
-}
-output "platform_kibana_lb_dns_name" {
-  value = "${module.logsearch.platform_kibana_lb_dns_name}"
-}
 output "platform_kibana_lb_target_group" {
   value = "${module.logsearch.platform_kibana_lb_target_group}"
 }
@@ -342,24 +346,12 @@ output "star_18f_gov_elb_dns_name" {
 output "shibboleth_elb_name" {
   value = "${module.shibboleth.shibboleth_elb_name}"
 }
-
 output "shibboleth_elb_dns_name" {
   value = "${module.shibboleth.shibboleth_elb_dns_name}"
 }
-
 output "shibboleth_elb_zone_id" {
   value = "${module.shibboleth.shibboleth_elb_zone_id}"
 }
-
-/* Shibboleth Proxy LB */
-output "shibboleth_lb_name" {
-  value = "${module.shibboleth.shibboleth_lb_name}"
-}
-
-output "shibboleth_lb_dns_name" {
-  value = "${module.shibboleth.shibboleth_lb_dns_name}"
-}
-
 output "shibboleth_lb_target_group" {
   value = "${module.shibboleth.shibboleth_lb_target_group}"
 }

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -319,6 +319,16 @@ output "platform_kibana_elb_dns_name" {
   value = "${module.logsearch.platform_kibana_elb_dns_name}"
 }
 
+output "platform_kibana_lb_name" {
+  value = "${module.logsearch.platform_kibana_lb_name}"
+}
+output "platform_kibana_lb_dns_name" {
+  value = "${module.logsearch.platform_kibana_lb_dns_name}"
+}
+output "platform_kibana_lb_target_group" {
+  value = "${module.logsearch.platform_kibana_lb_target_group}"
+}
+
 /* Client ELBs */
 output "star_18f_gov_elb_name" {
   value = "${module.client-elbs.star_18f_gov_elb_name}"
@@ -339,6 +349,19 @@ output "shibboleth_elb_dns_name" {
 
 output "shibboleth_elb_zone_id" {
   value = "${module.shibboleth.shibboleth_elb_zone_id}"
+}
+
+/* Shibboleth Proxy LB */
+output "shibboleth_lb_name" {
+  value = "${module.shibboleth.shibboleth_lb_name}"
+}
+
+output "shibboleth_lb_dns_name" {
+  value = "${module.shibboleth.shibboleth_lb_dns_name}"
+}
+
+output "shibboleth_lb_target_group" {
+  value = "${module.shibboleth.shibboleth_lb_target_group}"
 }
 
 /* iam roles */

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -149,6 +149,7 @@ module "shibboleth" {
     source = "../../modules/shibboleth"
 
     stack_description = "${var.stack_description}"
+    vpc_id = "${module.stack.vpc_id}"
     elb_subnets = ["${module.stack.public_subnet_az1}","${module.stack.public_subnet_az2}"]
 
     elb_shibboleth_cert_id = "${var.elb_shibboleth_cert_name != "" ?

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -35,11 +35,22 @@ variable "target_stack_name" {
 variable "main_cert_name" {
   default = ""
 }
+variable "use_apps_certificate" {}
 variable "apps_cert_name" {
   default = ""
 }
 variable "wildcard_prefix" {
   default = ""
+}
+
+variable "cf_hosts" {
+  type = "list"
+}
+variable "shibboleth_hosts" {
+  type = "list"
+}
+variable "platform_kibana_hosts" {
+  type = "list"
 }
 
 variable "services_cidr_1" {}

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -55,6 +55,11 @@ resource "aws_lb_target_group" "opsuaa_target" {
     path = "/healthz"
     matcher = 200
   }
+
+  stickiness {
+    type = "lb_cookie"
+    enabled = true
+  }
 }
 
 resource "aws_lb_listener" "opsuaa_listener" {

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -33,3 +33,41 @@ resource "aws_app_cookie_stickiness_policy" "opslogin_jsession_stickiness" {
   lb_port = 443
   cookie_name = "JSESSIONID"
 }
+
+resource "aws_lb" "opsuaa" {
+  name = "${var.stack_description}-opsuaa"
+  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  idle_timeout = 3600
+}
+
+resource "aws_lb_target_group" "opsuaa_target" {
+  name     = "${var.stack_description}-opsuaa"
+  port     = 8081
+  protocol = "HTTP"
+  vpc_id   = "${module.stack.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 61
+    timeout = 60
+    unhealthy_threshold = 3
+    path = "/healthz"
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener" "opsuaa_listener" {
+  load_balancer_arn = "${aws_lb.opsuaa.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = "${var.production_cert_name != "" ?
+    "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.production_cert_name}" :
+    data.aws_iam_server_certificate.wildcard_production.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.opsuaa_target.arn}"
+    type             = "forward"
+  }
+}

--- a/terraform/stacks/tooling/nessus_elb.tf
+++ b/terraform/stacks/tooling/nessus_elb.tf
@@ -32,6 +32,7 @@ resource "aws_lb_target_group" "nessus_target" {
   vpc_id   = "${module.stack.vpc_id}"
 
   health_check {
+    protocol = "HTTPS"
     healthy_threshold = 2
     interval = 61
     timeout = 60

--- a/terraform/stacks/tooling/nessus_elb.tf
+++ b/terraform/stacks/tooling/nessus_elb.tf
@@ -1,6 +1,6 @@
 resource "aws_elb" "nessus_elb" {
   name = "${var.stack_description}-Nessus"
-  subnets = ["${module.stack.public_subnet_az1}" ,"${module.stack.public_subnet_az2}"] 
+  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"] 
   security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
 
   listener {
@@ -20,8 +20,36 @@ resource "aws_elb" "nessus_elb" {
     unhealthy_threshold = 3
   }
 
-  tags =  {
+  tags {
     Name = "${var.stack_description}-Nessus"
   }
+}
 
+resource "aws_lb_target_group" "nessus_target" {
+  name     = "${var.stack_description}-nessus"
+  port     = 8834
+  protocol = "HTTPS"
+  vpc_id   = "${module.stack.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 61
+    timeout = 60
+    unhealthy_threshold = 3
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener_rule" "nessus_listener_rule" {
+  listener_arn = "${aws_lb_listener.main.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.nessus_target.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["${var.nessus_hosts}"]
+  }
 }

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -240,6 +240,9 @@ output "production_concourse_elb_dns_name" {
 output "production_concourse_elb_name" {
   value = "${module.concourse_production.concourse_elb_name}"
 }
+output "production_concourse_lb_target_group" {
+  value = "${module.concourse_production.concourse_lb_target_group}"
+}
 
 /* Staging Concourse */
 output "staging_concourse_subnet" {
@@ -284,6 +287,9 @@ output "staging_concourse_elb_dns_name" {
 output "staging_concourse_elb_name" {
   value = "${module.concourse_staging.concourse_elb_name}"
 }
+output "staging_concourse_lb_target_group" {
+  value = "${module.concourse_staging.concourse_lb_target_group}"
+}
 
 /* Production Monitoring */
 output "production_monitoring_az" {
@@ -300,6 +306,9 @@ output "production_prometheus_elb_dns_name" {
 }
 output "production_prometheus_elb_name" {
   value = "${module.monitoring_production.prometheus_elb_name}"
+}
+output "production_monitoring_lb_target_group" {
+  value = "${module.monitoring_production.lb_target_group}"
 }
 
 output "monitoring_security_groups" {
@@ -325,6 +334,9 @@ output "staging_prometheus_elb_dns_name" {
 }
 output "staging_prometheus_elb_name" {
   value = "${module.monitoring_staging.prometheus_elb_name}"
+}
+output "staging_monitoring_lb_target_group" {
+  value = "${module.monitoring_staging.lb_target_group}"
 }
 
 /* billing user */
@@ -390,6 +402,10 @@ output "nessus_elb_name" {
   value = "${aws_elb.nessus_elb.name}"
 }
 
+output "nessus_target_group" {
+  value = "${aws_lb_target_group.nessus_target.name}"
+}
+
 output "nessus_static_ip" {
   value = "${cidrhost("${var.private_cidr_1}", 71)}"
 }
@@ -398,9 +414,18 @@ output "nessus_static_ip" {
 output "bosh_uaa_elb_dns_name" {
   value = "${aws_elb.bosh_uaa_elb.dns_name}"
 }
-
 output "bosh_uaa_elb_name" {
   value = "${aws_elb.bosh_uaa_elb.name}"
+}
+
+output "opsuaa_lb_dns_name" {
+  value = "${aws_lb.opsuaa.dns_name}"
+}
+output "opsuaa_lb_name" {
+  value = "${aws_lb.opsuaa.name}"
+}
+output "opsuaa_target_group" {
+  value = "${aws_lb_target_group.opsuaa_target.name}"
 }
 
 /* DNS static IPs */

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -22,6 +22,43 @@ locals {
   aws_partition = "${element(split(":", data.aws_caller_identity.current.arn), 1)}"
 }
 
+resource "aws_lb" "main" {
+  name = "${var.stack_description}-main"
+  subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
+  security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  idle_timeout = 3600
+}
+
+resource "aws_lb_target_group" "dummy" {
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${module.stack.vpc_id}"
+}
+
+resource "aws_lb_listener" "main" {
+  load_balancer_arn = "${aws_lb.main.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = "${var.production_cert_name != "" ?
+    "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.production_cert_name}" :
+    data.aws_iam_server_certificate.wildcard_production.arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.dummy.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_certificate" "main-staging" {
+  count = "${var.use_staging_certificate ? 1 : 0}"
+
+  listener_arn    = "${aws_lb_listener.main.arn}"
+  certificate_arn = "${var.staging_cert_name != "" ?
+    "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.staging_cert_name}" :
+    data.aws_iam_server_certificate.wildcard_staging.arn}"
+}
+
 module "stack" {
   source = "../../modules/stack/base"
 
@@ -62,6 +99,8 @@ module "concourse_production" {
     data.aws_iam_server_certificate.wildcard_production.arn}"
   elb_subnets = ["${module.stack.public_subnet_az1}"]
   elb_security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  listener_arn = "${aws_lb_listener.main.arn}"
+  hosts = ["${var.concourse_production_hosts}"]
 }
 
 module "concourse_staging" {
@@ -83,6 +122,8 @@ module "concourse_staging" {
     data.aws_iam_server_certificate.wildcard_staging.arn}"
   elb_subnets = ["${module.stack.public_subnet_az2}"]
   elb_security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
+  listener_arn = "${aws_lb_listener.main.arn}"
+  hosts = ["${var.concourse_staging_hosts}"]
 }
 
 module "monitoring_production" {
@@ -98,6 +139,8 @@ module "monitoring_production" {
   elb_subnets = ["${module.stack.public_subnet_az1}"]
   elb_security_groups = ["${module.stack.web_traffic_security_group}"]
   prometheus_elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
+  listener_arn = "${aws_lb_listener.main.arn}"
+  hosts = ["${var.monitoring_production_hosts}"]
 }
 
 module "monitoring_staging" {
@@ -113,6 +156,8 @@ module "monitoring_staging" {
   elb_subnets = ["${module.stack.public_subnet_az2}"]
   elb_security_groups = ["${module.stack.web_traffic_security_group}"]
   prometheus_elb_security_groups = "${module.stack.restricted_web_traffic_security_group}"
+  listener_arn = "${aws_lb_listener.main.arn}"
+  hosts = ["${var.monitoring_staging_hosts}"]
 }
 
 resource "aws_eip" "production_dns_eip" {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -29,12 +29,6 @@ resource "aws_lb" "main" {
   idle_timeout = 3600
 }
 
-resource "aws_lb_target_group" "dummy" {
-  port     = 80
-  protocol = "HTTP"
-  vpc_id   = "${module.stack.vpc_id}"
-}
-
 resource "aws_lb_listener" "main" {
   load_balancer_arn = "${aws_lb.main.arn}"
   port              = "443"
@@ -48,6 +42,12 @@ resource "aws_lb_listener" "main" {
     target_group_arn = "${aws_lb_target_group.dummy.arn}"
     type             = "forward"
   }
+}
+
+resource "aws_lb_target_group" "dummy" {
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${module.stack.vpc_id}"
 }
 
 resource "aws_lb_listener_certificate" "main-staging" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -72,6 +72,32 @@ variable "wildcard_staging_prefix" {
   default = ""
 }
 
+variable "production_cert_name" {
+  default = ""
+}
+variable "use_staging_certificate" {}
+variable "staging_cert_name" {
+  default = ""
+}
+
+variable "concourse_production_hosts" {
+  type = "list"
+}
+variable "concourse_staging_hosts" {
+  type = "list"
+}
+
+variable "monitoring_production_hosts" {
+  type = "list"
+}
+variable "monitoring_staging_hosts" {
+  type = "list"
+}
+
+variable "nessus_hosts" {
+  type = "list"
+}
+
 variable "restricted_ingress_web_cidrs" {
   type = "list"
 }


### PR DESCRIPTION
Part of a multi-step process to replace public-facing ELBs with ALBs or NLBs.

1. Deploy ALBs/NLBs alongside existing ELBs
1. Attach EC2 instances to both ELBs and ALBs/NLBs
1. Point DNS records to ALBs/NLBs
1. Delete ELBs

I ran into this initially because the interface for setting TLS security policies on ELBs is irritating, but becomes straightforward with ALBs/NLBs. But there are other benefits. Now that ALBs have content-based routing and support SNI, we can use a single ALB for many services. This saves a little money and simplifies our terraform configuration.