### PR TITLE
Point DNS to ALBs.

### DIFF
--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -1,7 +1,6 @@
 cg_provision_git_url: https://github.com/18F/cg-provision.git
 cg_provision_git_repo: 18F/cg-provision
-cg_provision_git_branch: alb-dns-redux
-# cg_provision_git_branch: master
+cg_provision_git_branch: master
 
 pipeline_tasks_git_url: https://github.com/18F/cg-pipeline-tasks.git
 pipeline_tasks_git_branch: master
@@ -27,6 +26,5 @@ slack-channel: "#cg-platform"
 slack-username: concourse
 slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 
-cg_provision_development_git_branch: alb-dns-redux
+cg_provision_development_git_branch: master
 cg_provision_development_git_url: https://github.com/18F/cg-provision
-

--- a/ci/concourse-defaults.yml
+++ b/ci/concourse-defaults.yml
@@ -1,6 +1,7 @@
 cg_provision_git_url: https://github.com/18F/cg-provision.git
 cg_provision_git_repo: 18F/cg-provision
-cg_provision_git_branch: master
+cg_provision_git_branch: alb-dns-redux
+# cg_provision_git_branch: master
 
 pipeline_tasks_git_url: https://github.com/18F/cg-pipeline-tasks.git
 pipeline_tasks_git_branch: master
@@ -26,6 +27,6 @@ slack-channel: "#cg-platform"
 slack-username: concourse
 slack-icon-url: http://cl.ly/image/3e1h0H3H2s0P/concourse-logo.png
 
-cg_provision_development_git_branch: master
+cg_provision_development_git_branch: alb-dns-redux
 cg_provision_development_git_url: https://github.com/18F/cg-provision
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -157,6 +157,7 @@ jobs:
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_remote_state_region: ((aws_default_region))
       TF_VAR_tooling_stack_name: tooling
+      TF_VAR_production_stack_name: production
       TF_VAR_staging_stack_name: staging
   - *notify-slack
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -154,6 +154,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ((aws_external_access_key_id))
       AWS_SECRET_ACCESS_KEY: ((aws_external_secret_access_key))
       AWS_DEFAULT_REGION: ((aws_external_region))
+      TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
+      TF_VAR_tooling_stack_name: tooling
   - *notify-slack
 
 - name: apply-dns

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -157,6 +157,7 @@ jobs:
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
       TF_VAR_remote_state_region: ((aws_default_region))
       TF_VAR_tooling_stack_name: tooling
+      TF_VAR_staging_stack_name: staging
   - *notify-slack
 
 - name: apply-dns

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,10 +151,11 @@ jobs:
       STACK_NAME: dns
       TEMPLATE_SUBDIR: terraform/stacks/dns
       S3_TFSTATE_BUCKET: ((aws_external_s3_tfstate_bucket))
-      AWS_ACCESS_KEY_ID: ((aws_external_access_key_id))
-      AWS_SECRET_ACCESS_KEY: ((aws_external_secret_access_key))
-      AWS_DEFAULT_REGION: ((aws_external_region))
+      TF_VAR_aws_access_key: ((aws_external_access_key_id))
+      TF_VAR_aws_secret_key: ((aws_external_secret_access_key))
+      TF_VAR_aws_region: ((aws_external_region))
       TF_VAR_remote_state_bucket: ((aws_s3_tfstate_bucket))
+      TF_VAR_remote_state_region: ((aws_default_region))
       TF_VAR_tooling_stack_name: tooling
   - *notify-slack
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -309,7 +309,6 @@ jobs:
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "false"
       TF_VAR_use_apps_certificate: "false"
-      TF_VAR_cf_hosts: '["*.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_shibboleth_hosts: '["idp.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
   - *notify-slack
@@ -422,7 +421,6 @@ jobs:
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "true"
       TF_VAR_use_apps_certificate: "false"
-      TF_VAR_cf_hosts: '["*.fr-stage.cloud.gov"]'
       TF_VAR_shibboleth_hosts: '["idp.fr-stage.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr-stage.cloud.gov"]'
   - *notify-slack
@@ -535,7 +533,6 @@ jobs:
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
       TF_VAR_use_nat_gateway_eip: "true"
       TF_VAR_use_apps_certificate: "true"
-      TF_VAR_cf_hosts: '["*.fr.cloud.gov", "*.app.cloud.gov", "*.18f.gov"]'
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
   - *notify-slack

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -31,3 +31,57 @@ resource "aws_elb" "cloudfoundry_elb_apps" {
     Name = "${var.stack_description}-CloudFoundry-Apps"
   }
 }
+
+resource "aws_lb" "cf_apps" {
+  name = "${var.stack_description}-cloudfoundry-apps"
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
+  idle_timeout = 3600
+}
+
+resource "aws_lb_target_group" "cf_apps_target" {
+  name     = "${var.stack_description}-cf-apps"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 5
+    port = 81
+    timeout = 4
+    unhealthy_threshold = 3
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener" "cf_apps" {
+  load_balancer_arn = "${aws_lb.cf_apps.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = "${var.elb_apps_cert_id}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.cf_apps_target.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "cf_apps_http" {
+  load_balancer_arn = "${aws_lb.cf_apps.arn}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.cf_apps_target.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener_certificate" "cf_apps" {
+  count = "${length(var.additional_certificates)}"
+
+  listener_arn    = "${aws_lb_listener.cf_apps.arn}"
+  certificate_arn = "${element(var.additional_certificates, count.index)}"
+}

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -78,10 +78,3 @@ resource "aws_lb_listener" "cf_http" {
     type             = "forward"
   }
 }
-
-resource "aws_lb_listener_certificate" "cf" {
-  count = "${length(var.additional_certificates)}"
-
-  listener_arn    = "${aws_lb_listener.cf.arn}"
-  certificate_arn = "${element(var.additional_certificates, count.index)}"
-}

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -32,6 +32,13 @@ resource "aws_elb" "cloudfoundry_elb_main" {
   }
 }
 
+resource "aws_lb" "cf" {
+  name = "${var.stack_description}-cloudfoundry"
+  subnets = ["${var.elb_subnets}"]
+  security_groups = ["${var.elb_security_groups}"]
+  idle_timeout = 3600
+}
+
 resource "aws_lb_target_group" "cf_target" {
   name     = "${var.stack_description}-cf"
   port     = 80
@@ -48,36 +55,26 @@ resource "aws_lb_target_group" "cf_target" {
   }
 }
 
-resource "aws_lb_listener_rule" "cf" {
-  count = "${length(var.hosts)}"
+resource "aws_lb_listener" "cf" {
+  load_balancer_arn = "${aws_lb.cf.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = "${var.elb_main_cert_id}"
 
-  listener_arn = "${var.listener_arn}"
-  priority = "${1000 + count.index}"
-
-  action {
-    type             = "forward"
+  default_action {
     target_group_arn = "${aws_lb_target_group.cf_target.arn}"
-  }
-
-  condition {
-    field  = "host-header"
-    values = ["${element(var.hosts, count.index)}"]
+    type             = "forward"
   }
 }
 
-resource "aws_lb_listener_rule" "cf_http" {
-  count = "${length(var.hosts)}"
+resource "aws_lb_listener" "cf_http" {
+  load_balancer_arn = "${aws_lb.cf.arn}"
+  port              = "80"
+  protocol          = "HTTP"
 
-  listener_arn = "${var.http_listener_arn}"
-  priority = "${1000 + count.index}"
-
-  action {
-    type             = "forward"
+  default_action {
     target_group_arn = "${aws_lb_target_group.cf_target.arn}"
-  }
-
-  condition {
-    field  = "host-header"
-    values = ["${element(var.hosts, count.index)}"]
+    type             = "forward"
   }
 }

--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -78,3 +78,10 @@ resource "aws_lb_listener" "cf_http" {
     type             = "forward"
   }
 }
+
+resource "aws_lb_listener_certificate" "cf" {
+  count = "${length(var.additional_certificates)}"
+
+  listener_arn    = "${aws_lb_listener.cf.arn}"
+  certificate_arn = "${element(var.additional_certificates, count.index)}"
+}

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -22,6 +22,14 @@ output "elb_apps_name" {
   value = "${aws_elb.cloudfoundry_elb_apps.name}"
 }
 
+output "lb_name" {
+  value = "${aws_lb.cf.name}"
+}
+
+output "lb_dns_name" {
+  value = "${aws_lb.cf.dns_name}"
+}
+
 output "lb_target_group" {
   value = "${aws_lb_target_group.cf_target.name}"
 }

--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -30,8 +30,20 @@ output "lb_dns_name" {
   value = "${aws_lb.cf.dns_name}"
 }
 
+output "apps_lb_name" {
+  value = "${aws_lb.cf_apps.name}"
+}
+
+output "apps_lb_dns_name" {
+  value = "${aws_lb.cf_apps.dns_name}"
+}
+
 output "lb_target_group" {
   value = "${aws_lb_target_group.cf_target.name}"
+}
+
+output "apps_lb_target_group" {
+  value = "${aws_lb_target_group.cf_apps_target.name}"
 }
 
 output "cf_rds_url" {

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -2,6 +2,10 @@ variable "elb_main_cert_id" {}
 
 variable "elb_apps_cert_id" {}
 
+variable "additional_certificates" {
+  type = "list"
+}
+
 variable "elb_subnets" {
   type = "list"
 }

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -73,9 +73,3 @@ variable "aws_partition" {}
 variable "kubernetes_cluster_id" {}
 
 variable "bucket_prefix" {}
-
-variable "listener_arn" {}
-variable "http_listener_arn" {}
-variable "hosts" {
-  type = "list"
-}

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -275,7 +275,7 @@ resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_a" {
   name = "*.app.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
+    name = "dualstack.${data.terraform_remote_state.production.cf_apps_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -286,7 +286,7 @@ resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_aaaa" {
   name = "*.app.cloud.gov."
   type = "AAAA"
   alias {
-    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
+    name = "dualstack.${data.terraform_remote_state.production.cf_apps_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -21,14 +21,11 @@ variable "cloudfoundry_elb_logging_development" {
   default = "dualstack.development-CloudFoundry-Logging-1588361105.us-gov-west-1.elb.amazonaws.com"
 }
 
-variable "cloudfoundry_elb_logging_production" {
-  default = "dualstack.production-CloudFoundry-Logging-910586631.us-gov-west-1.elb.amazonaws.com"
-}
-
 variable "remote_state_bucket" {}
 variable "remote_state_region" {}
 
 variable "tooling_stack_name" {}
+variable "production_stack_name" {}
 variable "staging_stack_name" {}
 
 data "terraform_remote_state" "tooling" {
@@ -37,6 +34,15 @@ data "terraform_remote_state" "tooling" {
     bucket = "${var.remote_state_bucket}"
     region = "${var.remote_state_region}"
     key = "${var.tooling_stack_name}/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "production" {
+  backend = "s3"
+  config {
+    bucket = "${var.remote_state_bucket}"
+    region = "${var.remote_state_region}"
+    key = "${var.production_stack_name}/terraform.tfstate"
   }
 }
 
@@ -247,7 +253,7 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_a" {
   name = "*.fr.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.production-cloudfoundry-main-748290002.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -258,7 +264,7 @@ resource "aws_route53_record" "cloud_gov_star_fr_cloud_gov_aaaa" {
   name = "*.fr.cloud.gov."
   type = "AAAA"
   alias {
-    name = "dualstack.production-cloudfoundry-main-748290002.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -269,7 +275,7 @@ resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_a" {
   name = "*.app.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.production-cloudfoundry-apps-1021484088.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -280,7 +286,7 @@ resource "aws_route53_record" "cloud_gov_star_app_cloud_gov_aaaa" {
   name = "*.app.cloud.gov."
   type = "AAAA"
   alias {
-    name = "dualstack.production-cloudfoundry-apps-1021484088.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.production.cf_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -314,50 +320,6 @@ resource "aws_route53_record" "cloud_gov_ci_dev2_cloud_gov_a" {
   type = "A"
   alias {
     name = "dualstack.tooling-Concourse-us-gov-west-1a-1305041237.us-gov-west-1.elb.amazonaws.com."
-    zone_id = "${var.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_loggregator_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
-  name = "loggregator.fr.cloud.gov."
-  type = "A"
-  alias {
-    name = "${var.cloudfoundry_elb_logging_production}"
-    zone_id = "${var.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_loggregator_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
-  name = "loggregator.fr.cloud.gov."
-  type = "AAAA"
-  alias {
-    name = "${var.cloudfoundry_elb_logging_production}"
-    zone_id = "${var.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_doppler_fr_cloud_gov_a" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
-  name = "doppler.fr.cloud.gov."
-  type = "A"
-  alias {
-    name = "${var.cloudfoundry_elb_logging_production}"
-    zone_id = "${var.cloudfront_zone_id}"
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_record" "cloud_gov_doppler_fr_cloud_gov_aaaa" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
-  name = "doppler.fr.cloud.gov."
-  type = "AAAA"
-  alias {
-    name = "${var.cloudfoundry_elb_logging_production}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -21,11 +21,16 @@ variable "cloudfoundry_elb_logging_production" {
   default = "dualstack.production-CloudFoundry-Logging-910586631.us-gov-west-1.elb.amazonaws.com"
 }
 
-variable "elb_prometheus_staging" {
-  default = "dualstack.staging-Prometheus-658384006.us-gov-west-1.elb.amazonaws.com"
-}
-variable "elb_prometheus_production" {
-  default = "dualstack.production-Prometheus-1971082399.us-gov-west-1.elb.amazonaws.com"
+variable "remote_state_bucket" {}
+
+variable "tooling_stack_name" {}
+
+data "terraform_remote_state" "tooling" {
+  backend = "s3"
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key = "${var.tooling_stack_name}/terraform.tfstate"
+  }
 }
 
 resource "aws_route53_zone" "cloud_gov_zone" {
@@ -140,7 +145,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_a" {
   name = "prometheus.fr-stage.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -151,7 +156,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr-stage_cloud_gov_aaaa" {
   name = "prometheus.fr-stage.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -162,7 +167,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_a" {
   name = "alertmanager.fr-stage.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -173,7 +178,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr-stage_cloud_gov_aaaa" {
   name = "alertmanager.fr-stage.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -184,7 +189,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_a" {
   name = "grafana.fr-stage.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -195,7 +200,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_aaaa" {
   name = "grafana.fr-stage.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_staging}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -269,7 +274,7 @@ resource "aws_route53_record" "cloud_gov_ci-stage_fr_cloud_gov_a" {
   name = "ci.fr-stage.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.tooling-concourse-us-gov-west-1b-1960601158.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -280,7 +285,7 @@ resource "aws_route53_record" "cloud_gov_ci_fr_cloud_gov_a" {
   name = "ci.fr.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.tooling-concourse-us-gov-west-1a-1700142089.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -390,7 +395,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr_cloud_gov_a" {
   name = "prometheus.fr.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -401,7 +406,7 @@ resource "aws_route53_record" "cloud_gov_prometheus_fr_cloud_gov_aaaa" {
   name = "prometheus.fr.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -412,7 +417,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr_cloud_gov_a" {
   name = "alertmanager.fr.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -423,7 +428,7 @@ resource "aws_route53_record" "cloud_gov_alertmanager_fr_cloud_gov_aaaa" {
   name = "alertmanager.fr.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -434,7 +439,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr_cloud_gov_a" {
   name = "grafana.fr.cloud.gov."
   type = "A"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -445,7 +450,7 @@ resource "aws_route53_record" "cloud_gov_grafana_fr_cloud_gov_aaaa" {
   name = "grafana.fr.cloud.gov."
   type = "AAAA"
   alias {
-    name = "${var.elb_prometheus_production}"
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -524,7 +529,9 @@ resource "aws_route53_record" "cloud_gov_nessus_fr_cloud_gov_cname" {
   name = "nessus.fr.cloud.gov."
   type = "CNAME"
   ttl = 300
-  records = ["tooling-Nessus-1910336072.us-gov-west-1.elb.amazonaws.com"]
+  records = [
+    "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
+  ]
 }
 
 resource "aws_route53_record" "cloud_gov_ssh_fr_cloud_gov_a" {
@@ -543,7 +550,7 @@ resource "aws_route53_record" "cloud_gov_ops_uaa_fr_cloud_gov_a" {
   name = "opsuaa.fr.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.tooling-bosh-uaa-1089350571.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.tooling.opsuaa_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }
@@ -565,7 +572,7 @@ resource "aws_route53_record" "cloud_gov_ops_login_fr_cloud_gov_a" {
   name = "opslogin.fr.cloud.gov."
   type = "A"
   alias {
-    name = "dualstack.tooling-bosh-uaa-1089350571.us-gov-west-1.elb.amazonaws.com."
+    name = "dualstack.${data.terraform_remote_state.tooling.opsuaa_lb_dns_name}"
     zone_id = "${var.cloudfront_zone_id}"
     evaluate_target_health = false
   }

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -1,9 +1,16 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_region" {}
+
 terraform {
   backend "s3" {}
 }
 
 provider "aws" {
   version = "~> 1.12.0"
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region = "${var.aws_region}"
 }
 
 variable "cloudfront_zone_id" {
@@ -22,6 +29,7 @@ variable "cloudfoundry_elb_logging_production" {
 }
 
 variable "remote_state_bucket" {}
+variable "remote_state_region" {}
 
 variable "tooling_stack_name" {}
 
@@ -29,6 +37,7 @@ data "terraform_remote_state" "tooling" {
   backend = "s3"
   config {
     bucket = "${var.remote_state_bucket}"
+    region = "${var.remote_state_region}"
     key = "${var.tooling_stack_name}/terraform.tfstate"
   }
 }

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -152,6 +152,14 @@ output "main_lb_dns_name" {
   value = "${aws_lb.main.dns_name}"
 }
 
+/* CloudFoundry LB */
+output "cf_lb_name" {
+  value = "${module.cf.lb_name}"
+}
+output "cf_lb_dns_name" {
+  value = "${module.cf.lb_dns_name}"
+}
+
 /* Security Groups */
 output "bosh_security_group" {
   value = "${module.stack.bosh_security_group}"

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -160,6 +160,13 @@ output "cf_lb_dns_name" {
   value = "${module.cf.lb_dns_name}"
 }
 
+output "cf_apps_lb_name" {
+  value = "${module.cf.apps_lb_name}"
+}
+output "cf_apps_lb_dns_name" {
+  value = "${module.cf.apps_lb_dns_name}"
+}
+
 /* Security Groups */
 output "bosh_security_group" {
   value = "${module.stack.bosh_security_group}"
@@ -270,6 +277,9 @@ output "cf_apps_elb_name" {
 }
 output "cf_target_group" {
   value = "${module.cf.lb_target_group}"
+}
+output "cf_apps_target_group" {
+  value = "${module.cf.apps_lb_target_group}"
 }
 
 /* CloudFoundry RDS */

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -115,16 +115,13 @@ module "cf" {
     services_cidr_2 = "${var.services_cidr_2}"
     kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
     bucket_prefix = "${var.bucket_prefix}"
-    additional_certificates = ["${compact(list(
-      "${var.use_apps_certificate == "true" ?
-        "${var.apps_cert_name != "" ?
-          "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.apps_cert_name}" :
-          data.aws_iam_server_certificate.wildcard.arn}" :
-        ""}",
-      "${var.18f_gov_elb_cert_name != "" ?
-        "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.18f_gov_elb_cert_name}" :
-        ""}"
-    ))}"]
+    additional_certificates = ["${compact(
+      list(
+        "${var.18f_gov_elb_cert_name != "" ?
+          "arn:${local.aws_partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.18f_gov_elb_cert_name}" :
+          ""}"
+      )
+    )}"]
 }
 
 module "diego" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -49,17 +49,6 @@ resource "aws_lb_listener" "main" {
   }
 }
 
-resource "aws_lb_listener" "main_http" {
-  load_balancer_arn = "${aws_lb.main.arn}"
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.dummy.arn}"
-    type             = "forward"
-  }
-}
-
 resource "aws_lb_target_group" "dummy" {
   port     = 80
   protocol = "HTTP"
@@ -142,9 +131,6 @@ module "cf" {
     services_cidr_2 = "${var.services_cidr_2}"
     kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
     bucket_prefix = "${var.bucket_prefix}"
-    listener_arn = "${aws_lb_listener.main.arn}"
-    http_listener_arn = "${aws_lb_listener.main_http.arn}"
-    hosts = ["${var.cf_hosts}"]
 }
 
 module "diego" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -43,9 +43,6 @@ variable "wildcard_prefix" {
   default = ""
 }
 
-variable "cf_hosts" {
-  type = "list"
-}
 variable "shibboleth_hosts" {
   type = "list"
 }


### PR DESCRIPTION
Don't merge until ready to deprecate TLS 1.0 and 1.1!

* Switch records from ELBs to ALBs
* Drop records for names that are now resolved by host-based rules at the ALB level, like `idp.*`, `logs-platform.*`, `doppler.*`, etc.