### PR TITLE
Add count to listener rule priority for unique values.

### DIFF
--- a/terraform/modules/cloudfoundry/elb_main.tf
+++ b/terraform/modules/cloudfoundry/elb_main.tf
@@ -52,7 +52,7 @@ resource "aws_lb_listener_rule" "cf" {
   count = "${length(var.hosts)}"
 
   listener_arn = "${var.listener_arn}"
-  priority = 1000
+  priority = ${1000 + count.index}
 
   action {
     type             = "forward"
@@ -69,7 +69,7 @@ resource "aws_lb_listener_rule" "cf_http" {
   count = "${length(var.hosts)}"
 
   listener_arn = "${var.http_listener_arn}"
-  priority = 1000
+  priority = ${1000 + count.index}
 
   action {
     type             = "forward"

--- a/terraform/modules/logsearch/elb_platform_kibana.tf
+++ b/terraform/modules/logsearch/elb_platform_kibana.tf
@@ -44,7 +44,7 @@ resource "aws_lb_listener_rule" "platform_kibana" {
   count = "${length(var.hosts)}"
 
   listener_arn = "${var.listener_arn}"
-  priority = 200
+  priority = ${200 + count.index}
 
   action {
     target_group_arn = "${aws_lb_target_group.platform_kibana.arn}"

--- a/terraform/modules/shibboleth/shibboleth_elb_main.tf
+++ b/terraform/modules/shibboleth/shibboleth_elb_main.tf
@@ -58,7 +58,7 @@ resource "aws_lb_listener_rule" "shibboleth" {
   count = "${length(var.hosts)}"
 
   listener_arn = "${var.listener_arn}"
-  priority = 100
+  priority = ${100 + count.index}
 
   action {
     target_group_arn = "${aws_lb_target_group.shibboleth.arn}"


### PR DESCRIPTION
So that we don't run into conflicts where multiple listeners claim the same priority.