### PR TITLE
Use splats for outputs of resources with count.

### DIFF
--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -38,11 +38,11 @@ output "public_route_table" {
 }
 
 output "nat_egress_ip_az1" {
-  value = "${aws_eip.az1_nat_eip.public_ip}"
+  value = "${join(",", aws_eip.az1_nat_eip.*.public_ip)}"
 }
 
 output "nat_egress_ip_az2" {
-  value = "${aws_eip.az2_nat_eip.public_ip}"
+  value = "${join(",", aws_eip.az2_nat_eip.*.public_ip)}"
 }
 
 output "nat_private_ip_az1" {

--- a/terraform/modules/client-elbs/outputs.tf
+++ b/terraform/modules/client-elbs/outputs.tf
@@ -1,7 +1,7 @@
 output "star_18f_gov_elb_name" {
-  value = "${var.count == 1 ? aws_elb.star_18f_gov_elb.name : ""}"
+  value = "${join(",", aws_elb.star_18f_gov_elb.*.name)}"
 }
 
 output "star_18f_gov_elb_dns_name" {
-  value = "${var.count == 1 ? aws_elb.star_18f_gov_elb.dns_name : ""}"
+  value = "${join(",", aws_elb.star_18f_gov_elb.*.dns_name)}"
 }


### PR DESCRIPTION
As of terraform 0.11, outputs of resources that use `count` must use
splats. Use splats with `join` to match previous behavior.

Goes with https://github.com/18F/cg-deploy-concourse-docker-image/pull/39.