### PR TITLE
Fix cloudtrail s3 selector.

### DIFF
--- a/terraform/stacks/tooling/s3-logs.tf
+++ b/terraform/stacks/tooling/s3-logs.tf
@@ -43,7 +43,7 @@ resource "aws_cloudtrail" "cg-s3-cloudtrail-trail"{
 
     data_resource {
       type   = "AWS::S3::Object"
-      values = ["arn:${local.aws_partition}:s3:::cg-*"]
+      values = ["arn:${local.aws_partition}:s3:::cg-*/*"]
     }
   }
 }


### PR DESCRIPTION
Fixes `InvalidEventSelectorsException` error on limiting bucket logging
to `cg-*/*` prefix.