### PR TITLE
Grab all certs from iam cert resources.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -236,7 +236,6 @@ jobs:
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
       TF_VAR_wildcard_staging_certificate_name_prefix: star.fr-stage.cloud.gov
       TF_VAR_wildcard_production_certificate_name_prefix: star.fr.cloud.gov
-      TF_VAR_use_staging_certificate: "true"
       TF_VAR_use_nat_gateway_eip: "true"
   - *notify-slack
 

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -103,9 +103,7 @@ resource "aws_lb_listener" "domains_broker_https" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.main_cert_name != "" ?
-    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.main_cert_name}" :
-    data.aws_iam_server_certificate.wildcard.arn}"
+  certificate_arn = "${data.aws_iam_server_certificate.wildcard.arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.domains_broker_apps.*.arn[count.index]}"

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -43,9 +43,7 @@ resource "aws_lb_listener" "main" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.main_cert_name != "" ?
-    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.main_cert_name}" :
-    data.aws_iam_server_certificate.wildcard.arn}"
+  certificate_arn = "${data.aws_iam_server_certificate.wildcard.arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.dummy.arn}"
@@ -97,12 +95,8 @@ module "cf" {
 
     stack_description = "${var.stack_description}"
     aws_partition = "${data.aws_partition.current.partition}"
-    elb_main_cert_id = "${var.main_cert_name != "" ?
-      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.main_cert_name}" :
-      data.aws_iam_server_certificate.wildcard.arn}"
-    elb_apps_cert_id = "${var.apps_cert_name != "" ?
-      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.apps_cert_name}" :
-      data.aws_iam_server_certificate.wildcard_apps.arn}"
+    elb_main_cert_id = "${data.aws_iam_server_certificate.wildcard.arn}"
+    elb_apps_cert_id = "${data.aws_iam_server_certificate.wildcard_apps.arn}"
     elb_subnets = ["${module.stack.public_subnet_az1}", "${module.stack.public_subnet_az2}"]
     elb_security_groups = ["${var.force_restricted_network == "no" ?
       module.stack.web_traffic_security_group :

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -16,12 +16,6 @@ variable "target_stack_name" {
   default = "tooling"
 }
 
-variable "main_cert_name" {
-  default = ""
-}
-variable "apps_cert_name" {
-  default = ""
-}
 variable "wildcard_certificate_name_prefix" {
   default = ""
 }

--- a/terraform/stacks/tooling/elb_uaa.tf
+++ b/terraform/stacks/tooling/elb_uaa.tf
@@ -32,9 +32,7 @@ resource "aws_lb_listener" "opsuaa_listener" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.production_cert_name != "" ?
-    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.production_cert_name}" :
-    data.aws_iam_server_certificate.wildcard_production.arn}"
+  certificate_arn = "${data.aws_iam_server_certificate.wildcard_production.arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.opsuaa_target.arn}"

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -33,9 +33,7 @@ resource "aws_lb_listener" "main" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn = "${var.production_cert_name != "" ?
-    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.production_cert_name}" :
-    data.aws_iam_server_certificate.wildcard_production.arn}"
+  certificate_arn = "${data.aws_iam_server_certificate.wildcard_production.arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.dummy.arn}"
@@ -50,12 +48,8 @@ resource "aws_lb_target_group" "dummy" {
 }
 
 resource "aws_lb_listener_certificate" "main-staging" {
-  count = "${var.use_staging_certificate ? 1 : 0}"
-
   listener_arn    = "${aws_lb_listener.main.arn}"
-  certificate_arn = "${var.staging_cert_name != "" ?
-    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.staging_cert_name}" :
-    data.aws_iam_server_certificate.wildcard_staging.arn}"
+  certificate_arn = "${data.aws_iam_server_certificate.wildcard_staging.arn}"
 }
 
 module "stack" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -17,43 +17,12 @@ variable "rds_multi_az" {
 variable "remote_state_bucket" {}
 
 variable "concourse_prod_rds_password" {}
-variable "concourse_prod_elb_cert_name" {
-  default = "star-fr-cloud-gov-2017-05"
-}
-
 variable "concourse_staging_rds_password" {}
-variable "concourse_staging_elb_cert_name" {
-  default = "star-fr-stage-cloud-gov-2017-05"
-}
-
-variable "monitoring_production_elb_cert_name" {
-  default = "star-fr-cloud-gov-2017-05"
-}
-
-variable "monitoring_staging_elb_cert_name" {
-  default = "star-fr-stage-cloud-gov-2017-05"
-}
-
-variable "nessus_elb_cert_name" {
-  default = "star-fr-cloud-gov-2017-05"
-}
-
-variable "bosh_uaa_elb_cert_name" {
-  default = "star-fr-cloud-gov-2017-05"
-}
 
 variable "wildcard_production_certificate_name_prefix" {
   default = ""
 }
 variable "wildcard_staging_certificate_name_prefix" {
-  default = ""
-}
-
-variable "production_cert_name" {
-  default = ""
-}
-variable "use_staging_certificate" {}
-variable "staging_cert_name" {
   default = ""
 }
 


### PR DESCRIPTION
Now that we're using let's encrypt certs for all environments, we can drop the legacy `*_cert_name` variables. All certs are now provisioned from let's encrypt via concourse, uploaded to iam, and fetched via iam cert data sources.

We should confirm that no plans get changed as a result of this patch.