### PR TITLE
Bump production concourse database instance type.

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -86,7 +86,7 @@ module "concourse_production" {
   rds_subnet_group = "${module.stack.rds_subnet_group}"
   rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
   rds_parameter_group_name = "tooling-concourse-production"
-  rds_instance_type = "db.m4.xlarge"
+  rds_instance_type = "db.m4.2xlarge"
   rds_multi_az = "${var.rds_multi_az}"
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-production"
   listener_arn = "${aws_lb_listener.main.arn}"


### PR DESCRIPTION
Because production concourse has been using ~100% of cpu for the last few weeks.