### PR TITLE
[WIP] Drop `*.18f.gov` wildcard certificate.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -540,7 +540,6 @@ jobs:
       TF_VAR_restricted_ingress_web_ipv6_cidrs: ((production_restricted_ingress_web_ipv6_cidrs))
       TF_VAR_wildcard_certificate_name_prefix: star.fr.cloud.gov
       TF_VAR_wildcard_apps_certificate_name_prefix: star.app.cloud.gov
-      TF_VAR_18f_gov_elb_cert_name: star-18f-gov-04-18
       TF_VAR_stack_prefix: cf-production
       TF_VAR_bucket_prefix: cg
       TF_VAR_blobstore_bucket_name: bosh-prod-blobstore

--- a/terraform/modules/cloudfoundry/elb_apps.tf
+++ b/terraform/modules/cloudfoundry/elb_apps.tf
@@ -45,10 +45,3 @@ resource "aws_lb_listener" "cf_apps_http" {
     type             = "forward"
   }
 }
-
-resource "aws_lb_listener_certificate" "cf_apps" {
-  count = "${length(var.additional_certificates)}"
-
-  listener_arn    = "${aws_lb_listener.cf_apps.arn}"
-  certificate_arn = "${element(var.additional_certificates, count.index)}"
-}

--- a/terraform/modules/cloudfoundry/variables.tf
+++ b/terraform/modules/cloudfoundry/variables.tf
@@ -2,10 +2,6 @@ variable "elb_main_cert_id" {}
 
 variable "elb_apps_cert_id" {}
 
-variable "additional_certificates" {
-  type = "list"
-}
-
 variable "elb_subnets" {
   type = "list"
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -115,13 +115,6 @@ module "cf" {
     services_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 31)}"
     kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
     bucket_prefix = "${var.bucket_prefix}"
-    additional_certificates = ["${compact(
-      list(
-        "${var.18f_gov_elb_cert_name != "" ?
-          "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:server-certificate/${var.18f_gov_elb_cert_name}" :
-          ""}"
-      )
-    )}"]
 }
 
 module "diego" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -40,10 +40,6 @@ variable "restricted_ingress_web_ipv6_cidrs" {
   type = "list"
 }
 
-variable "18f_gov_elb_cert_name" {
-  default = ""
-}
-
 variable "stack_prefix" {}
 variable "bucket_prefix" {}
 variable "blobstore_bucket_name" {}


### PR DESCRIPTION
Note: don't merge until tock and c2 have moved off the wildcard cert.

Deprecated by custom domain brokers.