### PR TITLE
Revert "Allow concourse workers to inspect certificates"

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -55,14 +55,6 @@
         "arn:${aws_partition}:s3:::${varz_bucket}/master-bosh-state.json",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "elasticloadbalancing:DescribeLoadBalancers",
-        "iam:GetServerCertificate"
-      ],
-      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit a86ce193ceddf5cc417aaabf614b527b23d872da.

Goes with https://github.com/18F/cg-cert-check/pull/5.