### PR TITLE
Drop NAT gateway flags.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -237,7 +237,6 @@ jobs:
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
       TF_VAR_wildcard_staging_certificate_name_prefix: star.fr-stage.cloud.gov
       TF_VAR_wildcard_production_certificate_name_prefix: star.fr.cloud.gov
-      TF_VAR_use_nat_gateway_eip: "true"
   - *notify-slack
 
 - name: bootstrap-tooling
@@ -335,8 +334,6 @@ jobs:
       TF_VAR_bucket_prefix: development-cg
       TF_VAR_blobstore_bucket_name: bosh-development-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
-      TF_VAR_use_nat_gateway_eip: "true"
-      TF_VAR_use_nat_gateway_service: "true"
       TF_VAR_shibboleth_hosts: '["idp.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
@@ -441,7 +438,6 @@ jobs:
       TF_VAR_bucket_prefix: staging-cg
       TF_VAR_blobstore_bucket_name: bosh-staging-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
-      TF_VAR_use_nat_gateway_eip: "true"
       TF_VAR_shibboleth_hosts: '["idp.fr-stage.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr-stage.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
@@ -545,7 +541,6 @@ jobs:
       TF_VAR_bucket_prefix: cg
       TF_VAR_blobstore_bucket_name: bosh-prod-blobstore
       TF_VAR_upstream_blobstore_bucket_name: bosh-tooling-blobstore
-      TF_VAR_use_nat_gateway_eip: "true"
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"

--- a/terraform/modules/bosh_vpc/network_private.tf
+++ b/terraform/modules/bosh_vpc/network_private.tf
@@ -83,16 +83,6 @@ resource "aws_eip" "az2_nat_eip" {
   }
 }
 
-resource "aws_eip_association" "az1_nat_eip_association" {
-  instance_id   = "${aws_instance.az1_private_nat_2017_09.id}"
-  allocation_id = "${aws_eip.az1_nat_eip.id}"
-}
-
-resource "aws_eip_association" "az2_nat_eip_association" {
-  instance_id   = "${aws_instance.az2_private_nat_2017_09.id}"
-  allocation_id = "${aws_eip.az2_nat_eip.id}"
-}
-
 resource "aws_nat_gateway" "az1_private_nat_service" {
   allocation_id = "${aws_eip.az1_nat_eip.id}"
   subnet_id     = "${aws_subnet.az1_public.id}"

--- a/terraform/modules/bosh_vpc/outputs.tf
+++ b/terraform/modules/bosh_vpc/outputs.tf
@@ -61,14 +61,6 @@ output "nat_egress_ip_az2" {
   value = "${join(",", aws_eip.az2_nat_eip.*.public_ip)}"
 }
 
-output "nat_private_ip_az1" {
-  value = "${aws_instance.az1_private_nat_2017_09.private_ip}"
-}
-
-output "nat_private_ip_az2" {
-  value = "${aws_instance.az2_private_nat_2017_09.private_ip}"
-}
-
 /* Security Groups */
 output "bosh_security_group" {
   value = "${aws_security_group.bosh.id}"

--- a/terraform/modules/bosh_vpc/variables.tf
+++ b/terraform/modules/bosh_vpc/variables.tf
@@ -55,11 +55,3 @@ variable "concourse_security_groups" {
   type = "list"
   default = []
 }
-
-variable "use_nat_gateway_eip" {
-  default = false
-}
-
-variable "use_nat_gateway_service" {
-  default = false
-}

--- a/terraform/modules/stack/base/base.tf
+++ b/terraform/modules/stack/base/base.tf
@@ -15,8 +15,6 @@ module "vpc" {
     nat_gateway_instance_type = "${var.nat_gateway_instance_type}"
     monitoring_security_groups = "${var.target_monitoring_security_groups}"
     concourse_security_groups = "${var.target_concourse_security_groups}"
-    use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
-    use_nat_gateway_service = "${var.use_nat_gateway_service}"
 }
 
 module "rds_network" {

--- a/terraform/modules/stack/base/outputs.tf
+++ b/terraform/modules/stack/base/outputs.tf
@@ -52,14 +52,6 @@ output "nat_egress_ip_az2" {
   value = "${module.vpc.nat_egress_ip_az2}"
 }
 
-output "nat_private_ip_az1" {
-  value = "${module.vpc.nat_private_ip_az1}"
-}
-
-output "nat_private_ip_az2" {
-  value = "${module.vpc.nat_private_ip_az2}"
-}
-
 /* Security Groups */
 output "bosh_security_group" {
   value = "${module.vpc.bosh_security_group}"

--- a/terraform/modules/stack/base/variables.tf
+++ b/terraform/modules/stack/base/variables.tf
@@ -90,13 +90,6 @@ variable "target_concourse_security_groups" {
   default = []
 }
 
-variable "use_nat_gateway_eip" {
-  default = false
-}
-variable "use_nat_gateway_service" {
-  default = false
-}
-
 variable "rds_multi_az" {
   default = "true"
 }

--- a/terraform/modules/stack/spoke/outputs.tf
+++ b/terraform/modules/stack/spoke/outputs.tf
@@ -51,14 +51,6 @@ output "nat_egress_ip_az2" {
   value = "${module.base.nat_egress_ip_az2}"
 }
 
-output "nat_private_ip_az1" {
-  value = "${module.base.nat_private_ip_az1}"
-}
-
-output "nat_private_ip_az2" {
-  value = "${module.base.nat_private_ip_az2}"
-}
-
 /* Security Groups */
 output "bosh_security_group" {
   value = "${module.base.bosh_security_group}"

--- a/terraform/modules/stack/spoke/spoke.tf
+++ b/terraform/modules/stack/spoke/spoke.tf
@@ -28,8 +28,6 @@ module "base" {
     rds_security_groups_count = 2
     target_monitoring_security_groups = "${var.target_monitoring_security_groups}"
     target_concourse_security_groups = "${var.target_concourse_security_groups}"
-    use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
-    use_nat_gateway_service = "${var.use_nat_gateway_service}"
 }
 
 module "vpc_peering" {

--- a/terraform/modules/stack/spoke/variables.tf
+++ b/terraform/modules/stack/spoke/variables.tf
@@ -91,9 +91,3 @@ variable "target_concourse_security_groups" {
   type = "list"
   default = []
 }
-variable "use_nat_gateway_eip" {
-  default = false
-}
-variable "use_nat_gateway_service" {
-  default = false
-}

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -88,12 +88,6 @@ output "nat_egress_ip_az1" {
 output "nat_egress_ip_az2" {
   value = "${module.stack.nat_egress_ip_az2}"
 }
-output "nat_private_ip_az1" {
-  value = "${module.stack.nat_private_ip_az1}"
-}
-output "nat_private_ip_az2" {
-  value = "${module.stack.nat_private_ip_az2}"
-}
 
 /* Services network */
 output "services_subnet_az1" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -87,8 +87,6 @@ module "stack" {
       "${data.terraform_remote_state.target_vpc.production_concourse_security_group}",
       "${data.terraform_remote_state.target_vpc.staging_concourse_security_group}"
     ]
-    use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
-    use_nat_gateway_service = "${var.use_nat_gateway_service}"
 }
 
 module "cf" {

--- a/terraform/stacks/main/variables.tf
+++ b/terraform/stacks/main/variables.tf
@@ -48,11 +48,3 @@ variable "upstream_blobstore_bucket_name" {}
 variable "force_restricted_network" {
   default = "yes"
 }
-
-variable "use_nat_gateway_eip" {
-  default = false
-}
-
-variable "use_nat_gateway_service" {
-  default = false
-}

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -155,12 +155,6 @@ output "nat_egress_ip_az1" {
 output "nat_egress_ip_az2" {
   value = "${module.stack.nat_egress_ip_az2}"
 }
-output "nat_private_ip_az1" {
-  value = "${module.stack.nat_private_ip_az1}"
-}
-output "nat_private_ip_az2" {
-  value = "${module.stack.nat_private_ip_az2}"
-}
 
 /* Security Groups */
 output "bosh_security_group" {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -72,8 +72,6 @@ module "stack" {
   rds_multi_az = "${var.rds_multi_az}"
   rds_security_groups = ["${module.stack.bosh_security_group}"]
   rds_security_groups_count = "1"
-  use_nat_gateway_eip = "${var.use_nat_gateway_eip}"
-  use_nat_gateway_service = "${var.use_nat_gateway_service}"
 }
 
 module "concourse_production" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -98,19 +98,10 @@ variable "cg_binaries_bucket" {
    default = "cg-binaries"
 }
 
-variable "use_nat_gateway_eip" {
-  default = false
-}
-
-variable "use_nat_gateway_service" {
-  default = false
-}
-
 variable "smtp_ingress_cidr_blocks" {
   type = "list"
 }
 
 variable "cloudtrail_bucket" {
-   default = "cg-s3-cloudtrail"
+  default = "cg-s3-cloudtrail"
 }
-


### PR DESCRIPTION
Now that all subnets use managed NAT gateways, we can drop the EIP and
NAT gateway flags and configure all subnets the same way.