### PR TITLE
Enable sticky sessions for concourse load balancers.

### DIFF
--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -11,6 +11,11 @@ resource "aws_lb_target_group" "concourse_target" {
     interval = 30
     matcher = 200
   }
+
+  stickiness {
+    type = "lb_cookie"
+    enabled = true
+  }
 }
 
 resource "aws_lb_listener_rule" "concourse_listener_rule" {


### PR DESCRIPTION
Concourse atc instances appear to store session state in memory as of
concourse 4.0, so we need to use sticky sessions.