### PR TITLE
Revert "Bump production concourse database instance type."

### DIFF
--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -85,7 +85,7 @@ module "concourse_production" {
   rds_subnet_group = "${module.stack.rds_subnet_group}"
   rds_security_groups = ["${module.stack.rds_postgres_security_group}"]
   rds_parameter_group_name = "tooling-concourse-production"
-  rds_instance_type = "db.m4.2xlarge"
+  rds_instance_type = "db.m4.xlarge"
   rds_multi_az = "${var.rds_multi_az}"
   rds_final_snapshot_identifier = "final-snapshot-atc-tooling-production"
   listener_arn = "${aws_lb_listener.main.arn}"


### PR DESCRIPTION
This reverts commit 147e59327d06fcd144c5190f2613c553dc5db6ea.

Database load is way down after the concourse 4.0 release:

> We've made quite a few optimizations that should take a lot of load off the database. This should improve everything from garbage collection efficiency to web UI response time.

<img width="333" alt="screen shot 2018-07-29 at 5 17 01 pm" src="https://user-images.githubusercontent.com/1633460/43370913-9ad7287e-9355-11e8-9263-77a88878d538.png">

We shouldn't need a 2xlarge anymore.