### PR TITLE
Renew certificates 30 days before expiry.

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -16,7 +16,7 @@ chmod +x ./spruce
 expiration=$(
   ./jq -r '.ServerCertificateMetadataList | sort_by(.Expiration) | .[-1].Expiration' \
     < certificates/metadata)
-if [ $(date --date "+14 days" +%s) -lt $(date --date "${expiration}" +%s) ]; then
+if [ $(date --date "+30 days" +%s) -lt $(date --date "${expiration}" +%s) ]; then
   exit 0
 fi
 


### PR DESCRIPTION
To match alerting intervals in https://github.com/18F/cg-deploy-prometheus/blob/master/bosh/opsfiles/rules.yml.