### PR TITLE
Check both path and name prefixes on listing certificates.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -634,6 +634,7 @@ jobs:
   - task: provision-certificate
     file: cg-provision-repo/ci/provision-certificate.yml
     params:
+      CERT_PREFIX: star.dev.us-gov-west-1.aws-us-gov.cloud.gov
       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
       DOMAIN: "*.dev.us-gov-west-1.aws-us-gov.cloud.gov"
       EMAIL: cloud-gov-operations@gsa.gov
@@ -671,6 +672,7 @@ jobs:
   - task: provision-certificate
     file: cg-provision-repo/ci/provision-certificate.yml
     params:
+      CERT_PREFIX: star.fr-stage.cloud.gov
       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
       DOMAIN: "*.fr-stage.cloud.gov"
       EMAIL: cloud-gov-operations@gsa.gov
@@ -708,6 +710,7 @@ jobs:
   - task: provision-certificate
     file: cg-provision-repo/ci/provision-certificate.yml
     params:
+      CERT_PREFIX: star.fr.cloud.gov
       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
       DOMAIN: "*.fr.cloud.gov"
       EMAIL: cloud-gov-operations@gsa.gov
@@ -745,6 +748,7 @@ jobs:
   - task: provision-certificate
     file: cg-provision-repo/ci/provision-certificate.yml
     params:
+      CERT_PREFIX: star.app.cloud.gov
       ACME_SERVER: https://acme-v02.api.letsencrypt.org/directory
       DOMAIN: "*.app.cloud.gov"
       EMAIL: cloud-gov-operations@gsa.gov

--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -14,7 +14,8 @@ chmod +x ./spruce
 
 # Quit if current certificate isn't close to expiration date
 expiration=$(
-  ./jq -r '.ServerCertificateMetadataList | sort_by(.Expiration) | .[-1].Expiration' \
+  ./jq -r --arg prefix "${CERT_PREFIX}-" \
+    '.ServerCertificateMetadataList | map(select(.ServerCertificateName | startswith($prefix))) | sort_by(.Expiration) | .[-1].Expiration' \
     < certificates/metadata)
 if [ $(date --date "+30 days" +%s) -lt $(date --date "${expiration}" +%s) ]; then
   exit 0


### PR DESCRIPTION
Because we may have multiple certificate name prefixes within a single
path prefix, we need to consider both path prefix and name prefix for
checking expiration dates. Prior to this fix, we might update the
`*.fr.cloud.gov` certificate but not `*.app.cloud.gov`, or vice versa.