### PR TITLE
Revert "Enable sticky sessions for concourse load balancers."

### DIFF
--- a/terraform/modules/concourse/elb.tf
+++ b/terraform/modules/concourse/elb.tf
@@ -11,11 +11,6 @@ resource "aws_lb_target_group" "concourse_target" {
     interval = 30
     matcher = 200
   }
-
-  stickiness {
-    type = "lb_cookie"
-    enabled = true
-  }
 }
 
 resource "aws_lb_listener_rule" "concourse_listener_rule" {


### PR DESCRIPTION
This reverts commit f41fd27e1f2cbaea2fa4a1c157445c0ce52850fd.

Now that concourse 4.1 has been released with a fix for https://github.com/concourse/concourse/issues/2425, we shouldn't need sticky sessions on the load balancer anymore. To verify without risking a production outage, merge https://github.com/18F/cg-deploy-concourse/pull/100, manually disable sticky sessions on staging, and verify that authentication continues to work.

@sharms @LinuxBozo 