### PR TITLE
Add in necessary params

### DIFF
--- a/ci/check-certificates.yml
+++ b/ci/check-certificates.yml
@@ -15,3 +15,7 @@ outputs:
 
 run:
   path: cg-provision-repo/ci/check-certificates.sh
+
+params:
+  AWS_DEFAULT_REGION:
+  CERT_PATH:

--- a/ci/provision-certificate.yml
+++ b/ci/provision-certificate.yml
@@ -17,3 +17,9 @@ outputs:
 
 run:
   path: cg-provision-repo/ci/provision-certificate.sh
+
+params:
+  CERT_PREFIX:
+  ACME_SERVER:
+  DOMAIN:
+  EMAIL: cloud-gov-operations@gsa.gov

--- a/ci/upload-certificate.yml
+++ b/ci/upload-certificate.yml
@@ -14,3 +14,8 @@ inputs:
 
 run:
   path: cg-provision-repo/ci/upload-certificate.sh
+
+params:
+  AWS_DEFAULT_REGION:
+  CERT_PATH:
+  CERT_PREFIX:


### PR DESCRIPTION
This behavior has been deprecated since 4.1.0 and will eventually cause an error in later Concourse versions.
https://concourse-ci.org/download.html#v410