### PR TITLE
Fix the path issues for $out_path

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -34,5 +34,5 @@ certbot certonly \
   --email "${EMAIL}" \
   --domain "${DOMAIN}"
 
-out_path=$(ls "${config_path}/live")
+out_path=$(ls -d -1 ${config_path}/live/*/)
 cp ${config_path}/live/${out_path}/*.pem acme


### PR DESCRIPTION
Seems like `$out_path` now includes a `README` file, so `cp` is having
issues finding the files. I've tested this in a Concourse worker to
determine that we should only be listing directories from the `live/`
directory and skip over any of the files in there such as `README`.

_This is brittle enough that it will break again if there's another
directory._

**This has been causing our certificate pipelines to fail**. This seems
unrelated to an issue that was brought up in #cg-support though around
certificates expiring.