### PR TITLE
When leveraging -d, we get a full path

### DIFF
--- a/ci/provision-certificate.sh
+++ b/ci/provision-certificate.sh
@@ -35,4 +35,4 @@ certbot certonly \
   --domain "${DOMAIN}"
 
 out_path=$(ls -d -1 ${config_path}/live/*/)
-cp ${config_path}/live/${out_path}/*.pem acme
+cp ${out_path}/*.pem acme


### PR DESCRIPTION
So we should reference `${out_path}` as a full path and not as a part of
a larger path.