### PR TITLE
Retain for 120 days instead of 30 days

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "rds_database" {
     "final-snapshot-${var.rds_db_name}-${var.stack_description}" :
     var.rds_final_snapshot_identifier}"
 
-  backup_retention_period = 30
+  backup_retention_period = 120
 
   auto_minor_version_upgrade = true
 


### PR DESCRIPTION
This came out of our annual assessment / contingency planning. We should be retaining these backups for much longer than we were originally.