### PR TITLE
Retain for the max instead of 120 days instead

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -13,7 +13,7 @@ resource "aws_db_instance" "rds_database" {
     "final-snapshot-${var.rds_db_name}-${var.stack_description}" :
     var.rds_final_snapshot_identifier}"
 
-  backup_retention_period = 120
+  backup_retention_period = 35
 
   auto_minor_version_upgrade = true
 


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html

> After you create a DB instance, you can modify the backup retention period. You can set the backup retention period to between 0 and 35 days.