### PR TITLE
Enables access logs for {env}-main

### DIFF
--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,10 +36,10 @@ resource "aws_lb" "main" {
     module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
-
+  
   access_logs {
     bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "foo"
+    bucket_prefix = "${var.stack_description}"
     interval      = 5
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -39,7 +39,6 @@ resource "aws_lb" "main" {
   
   access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      interval      = 5
     }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -38,7 +38,7 @@ resource "aws_lb" "main" {
   idle_timeout = 3600
   
   access_logs {
-    bucket        = "cloud-gov-elb-logs"
+    bucket        = "cloud-gov-elb-logs-${var.stack_description}"
     bucket_prefix = "${var.stack_description}"
     interval      = 5
   }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,10 +36,10 @@ resource "aws_lb" "main" {
     module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
-
+  
   access_logs {
     bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "{var.stack_description}"
+    bucket_prefix = "${var.stack_description}"
     interval      = 5
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -37,12 +37,13 @@ resource "aws_lb" "main" {
   ip_address_type = "dualstack"
   idle_timeout = 3600
   
-  access_logs =  [
+  access_logs = [
     {
       bucket        = "cloud-gov-elb-logs"
       bucket_prefix = "${var.stack_description}"
       interval      = 5
     },
+  ]
 }
 
 resource "aws_lb_listener" "main" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -39,6 +39,7 @@ resource "aws_lb" "main" {
   
   access_logs = {
       bucket        = "cloud-gov-elb-logs"
+      interval      = 5
     }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,6 +36,12 @@ resource "aws_lb" "main" {
     module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
+  
+  access_logs {
+    bucket        = "cloud-gov-elb-logs"
+    bucket_prefix = "tooling"
+    interval      = 5
+  }
 }
 
 resource "aws_lb_listener" "main" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -37,11 +37,12 @@ resource "aws_lb" "main" {
   ip_address_type = "dualstack"
   idle_timeout = 3600
   
-  access_logs {
-    bucket        = "cloud-gov-elb-logs-${var.stack_description}"
-    bucket_prefix = "${var.stack_description}"
-    interval      = 5
-  }
+  access_logs =  [
+    {
+      bucket        = "cloud-gov-elb-logs"
+      bucket_prefix = "${var.stack_description}"
+      interval      = 5
+    },
 }
 
 resource "aws_lb_listener" "main" {

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -37,10 +37,8 @@ resource "aws_lb" "main" {
   ip_address_type = "dualstack"
   idle_timeout = 3600
   
-  access_logs.0 = {
+  access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      bucket_prefix = "${var.stack_description}"
-      interval      = 5
     }
 }
 

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,10 +36,10 @@ resource "aws_lb" "main" {
     module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
-  
+
   access_logs {
     bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "${var.stack_description}"
+    bucket_prefix = "foo"
     interval      = 5
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -36,10 +36,10 @@ resource "aws_lb" "main" {
     module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
-  
+
   access_logs {
     bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "tooling"
+    bucket_prefix = "{var.stack_description}"
     interval      = 5
   }
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -37,13 +37,11 @@ resource "aws_lb" "main" {
   ip_address_type = "dualstack"
   idle_timeout = 3600
   
-  access_logs = [
-    {
+  access_logs.0 = {
       bucket        = "cloud-gov-elb-logs"
       bucket_prefix = "${var.stack_description}"
       interval      = 5
-    },
-  ]
+    }
 }
 
 resource "aws_lb_listener" "main" {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -26,6 +26,12 @@ resource "aws_lb" "main" {
   security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
+
+  access_logs {
+    bucket        = "cloud-gov-elb-logs"
+    bucket_prefix = "{var.stack_description}"
+    interval      = 5
+  }
 }
 
 resource "aws_lb_listener" "main" {

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -29,7 +29,7 @@ resource "aws_lb" "main" {
 
   access_logs {
     bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "{var.stack_description}"
+    bucket_prefix = "${var.stack_description}"
     interval      = 5
   }
 }

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -26,12 +26,6 @@ resource "aws_lb" "main" {
   security_groups = ["${module.stack.restricted_web_traffic_security_group}"]
   ip_address_type = "dualstack"
   idle_timeout = 3600
-
-  access_logs {
-    bucket        = "cloud-gov-elb-logs"
-    bucket_prefix = "${var.stack_description}"
-    interval      = 5
-  }
 }
 
 resource "aws_lb_listener" "main" {


### PR DESCRIPTION
Directions for this found here: https://www.devopswiki.co.uk/wiki/terraform/terraform-elb-s3-access-logs

This will allow us have more insight into ELB failures.