### PR TITLE
Add access logs to all [AE]LBs

### DIFF
--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -81,4 +81,8 @@ resource "aws_elb" "diego_elb_main" {
   tags {
     Name = "${var.stack_description}-Diego-Proxy-ELB"
   }
+
+   access_logs = {
+      bucket        = "cloud-gov-elb-logs"
+    }
 }

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -22,4 +22,8 @@ resource "aws_elb" "elasticache_elb" {
   tags {
     Name = "${var.stack_description}-elasticache-broker"
   }
+
+   access_logs = {
+      bucket        = "cloud-gov-elb-logs"
+    }
 }

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -23,4 +23,8 @@ resource "aws_elb" "kubernetes_elb" {
   tags {
     Name = "${var.stack_description}-kubernetes"
   }
+
+   access_logs = {
+      bucket        = "cloud-gov-elb-logs"
+    }
 }

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -23,4 +23,8 @@ resource "aws_elb" "logsearch_elb" {
   tags {
     Name = "${var.stack_description}-logsearch"
   }
+
+   access_logs = {
+      bucket        = "cloud-gov-elb-logs"
+    }
 }

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -23,4 +23,8 @@ resource "aws_elb" "platform_syslog_elb" {
   tags {
     Name = "${var.stack_description}-platform-syslog"
   }
+
+   access_logs = {
+      bucket        = "cloud-gov-elb-logs"
+    }
 }


### PR DESCRIPTION
To assist with troubleshooting, we need to turn these on for all the A- and E-LBs.
Note that with this change, all the logs go into the same bucket and directories, but the filenames are unique based on bucket, I.E.:
`cloud-gov-elb-logs/AWSLogs/<account number>/elasticloadbalancing/<region>/<year>/<month>/<day>/<account_number>_elasticloadbalancing_<region>_app.<ELB name>.<magic string>_<timestamp>_<ip address>_<more magic strings>.log.gz`