### PR TITLE
ELBs and ALBs use different syntax

### DIFF
--- a/terraform/modules/diego/diego_elb_main.tf
+++ b/terraform/modules/diego/diego_elb_main.tf
@@ -84,6 +84,6 @@ resource "aws_elb" "diego_elb_main" {
 
    access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      prefix        = "${var.stack_description}"
+      bucket_prefix        = "${var.stack_description}"
     }
 }

--- a/terraform/modules/elasticache_broker_network/elb.tf
+++ b/terraform/modules/elasticache_broker_network/elb.tf
@@ -25,6 +25,6 @@ resource "aws_elb" "elasticache_elb" {
 
    access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      prefix        = "${var.stack_description}"
+      bucket_prefix        = "${var.stack_description}"
     }
 }

--- a/terraform/modules/kubernetes/elb.tf
+++ b/terraform/modules/kubernetes/elb.tf
@@ -26,6 +26,6 @@ resource "aws_elb" "kubernetes_elb" {
 
    access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      prefix        = "${var.stack_description}"
+      bucket_prefix        = "${var.stack_description}"
     }
 }

--- a/terraform/modules/logsearch/elb.tf
+++ b/terraform/modules/logsearch/elb.tf
@@ -26,6 +26,6 @@ resource "aws_elb" "logsearch_elb" {
 
    access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      prefix        = "${var.stack_description}"
+      bucket_prefix        = "${var.stack_description}"
     }
 }

--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -26,6 +26,6 @@ resource "aws_elb" "platform_syslog_elb" {
 
    access_logs = {
       bucket        = "cloud-gov-elb-logs"
-      prefix        = "${var.stack_description}"
+      bucket_prefix        = "${var.stack_description}"
     }
 }


### PR DESCRIPTION
Terraform helpfully uses a different keyword for prefix between ALBs and ELBs.