### PR TITLE
Fix variable setting

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -11,7 +11,7 @@ data "template_file" "policy" {
     buildpack_notify_bucket = "${var.buildpack_notify_bucket}"
     billing_bucket = "${var.billing_bucket}"
     cg_binaries_bucket = "${var.cg_binaries_bucket}"
-    log_bucket_name = "${var.log_bucket_name}"
+    log_bucket_name = "${var.log_bucket}"
   }
 }
 

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -11,7 +11,7 @@ data "template_file" "policy" {
     buildpack_notify_bucket = "${var.buildpack_notify_bucket}"
     billing_bucket = "${var.billing_bucket}"
     cg_binaries_bucket = "${var.cg_binaries_bucket}"
-    log_bucket_name = "${var.log_bucket}"
+    log_bucket = "${var.log_bucket}"
   }
 }
 

--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -50,7 +50,7 @@ resource "aws_s3_bucket" "log_bucket" {
                 {
                     "Effect": "Allow",
                     "Principal": {
-                        "AWS": "arn:${var.aws_partition}:iam::${local.aws_alb_account_ids[var.aws_partition]}:root"
+                        "AWS": "arn:${var.aws_partition}:iam::${local.aws_alb_account_ids[var.aws_region]}:root"
                     },
                     "Action": "s3:PutObject",
                     "Resource": "arn:aws-us-gov:s3:::${var.log_bucket_name}/*"

--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -43,7 +43,6 @@ resource "aws_s3_bucket" "log_bucket" {
     }
 
     policy = <<EOF
-    {
         {
             "Version": "2012-10-17",
             "Statement": [
@@ -57,6 +56,5 @@ resource "aws_s3_bucket" "log_bucket" {
                 }
             ]
         }
-    }
 EOF
 }

--- a/terraform/modules/log_bucket/variables.tf
+++ b/terraform/modules/log_bucket/variables.tf
@@ -9,3 +9,5 @@ variable "log_bucket_acl" {
 }
 
 variable "aws_partition" {}
+
+variable "aws_region" {}

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -9,4 +9,5 @@ module "log_bucket" {
   source = "../../modules/log_bucket"
   aws_partition = "${data.aws_partition.current.partition}"
   log_bucket_name = "${var.log_bucket_name}"
+  aws_region = "${data.aws_region.current}"
 }

--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -9,5 +9,5 @@ module "log_bucket" {
   source = "../../modules/log_bucket"
   aws_partition = "${data.aws_partition.current.partition}"
   log_bucket_name = "${var.log_bucket_name}"
-  aws_region = "${data.aws_region.current}"
+  aws_region = "${data.aws_region.current.name}"
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -120,7 +120,7 @@ module "cf" {
     services_cidr_2 = "${cidrsubnet(var.vpc_cidr, 8, 31)}"
     kubernetes_cluster_id = "${var.kubernetes_cluster_id}"
     bucket_prefix = "${var.bucket_prefix}"
-    log_bucket = "${var.log_bucket_name}"
+    log_bucket_name = "${var.log_bucket_name}"
 }
 
 module "diego" {
@@ -135,7 +135,7 @@ module "diego" {
     ingress_cidrs = "${split(",",
       var.force_restricted_network == "no" ?
         "0.0.0.0/0" : join(",", var.restricted_ingress_web_cidrs))}"
-    log_bucket = "${var.log_bucket_name}"
+    log_bucket_name = "${var.log_bucket_name}"
 }
 
 module "kubernetes" {
@@ -151,7 +151,7 @@ module "kubernetes" {
     target_bosh_security_group = "${module.stack.bosh_security_group}"
     target_monitoring_security_group = "${lookup(data.terraform_remote_state.target_vpc.monitoring_security_groups, var.stack_description)}"
     target_concourse_security_group = "${data.terraform_remote_state.target_vpc.production_concourse_security_group}"
-    log_bucket = "${var.log_bucket_name}"
+    log_bucket_name = "${var.log_bucket_name}"
 }
 
 module "logsearch" {
@@ -163,7 +163,7 @@ module "logsearch" {
     bosh_security_group = "${module.stack.bosh_security_group}"
     listener_arn = "${aws_lb_listener.main.arn}"
     hosts = ["${var.platform_kibana_hosts}"]
-    log_bucket = "${var.log_bucket_name}"
+    log_bucket_name = "${var.log_bucket_name}"
 }
 
 module "shibboleth" {
@@ -198,5 +198,5 @@ module "elasticache_broker_network" {
   security_groups = ["${module.stack.bosh_security_group}"]
   elb_subnets = ["${module.cf.services_subnet_az1}","${module.cf.services_subnet_az2}"]
   elb_security_groups = ["${module.stack.bosh_security_group}"]
-  log_bucket = "${var.log_bucket_name}"
+  log_bucket_name = "${var.log_bucket_name}"
 }

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -18,6 +18,8 @@ data "aws_partition" "current" {}
 data "aws_availability_zones" "available" {}
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 data "aws_iam_server_certificate" "wildcard" {
   name_prefix = "${var.wildcard_certificate_name_prefix}"
   latest = true

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -49,4 +49,5 @@ module "log_bucket" {
   source = "../../modules/log_bucket"
   aws_partition = "${data.aws_partition.current.partition}"
   log_bucket_name = "${var.log_bucket_name}"
+  aws_region = "${data.aws_region.current.name}"
 }

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -9,6 +9,7 @@ provider "aws" {
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
+data "aws_region" "current" {}
 
 data "aws_iam_server_certificate" "wildcard_production" {
   name_prefix = "${var.wildcard_production_certificate_name_prefix}"


### PR DESCRIPTION
This passes the log_bucket/log_bucket_name variables around correctly, and uses the aws_region for the region and aws_partition for the partition.
Happy plan builds:
[tooling](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/plan-bootstrap-tooling/builds/1536)
[staging](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/plan-bootstrap-staging/builds/1443)
[production](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/plan-bootstrap-production/builds/1440)