### PR TITLE
policies must start with {

### DIFF
--- a/terraform/modules/log_bucket/log_bucket.tf
+++ b/terraform/modules/log_bucket/log_bucket.tf
@@ -43,18 +43,18 @@ resource "aws_s3_bucket" "log_bucket" {
     }
 
     policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
         {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": "arn:${var.aws_partition}:iam::${local.aws_alb_account_ids[var.aws_region]}:root"
-                    },
-                    "Action": "s3:PutObject",
-                    "Resource": "arn:aws-us-gov:s3:::${var.log_bucket_name}/*"
-                }
-            ]
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:${var.aws_partition}:iam::${local.aws_alb_account_ids[var.aws_region]}:root"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws-us-gov:s3:::${var.log_bucket_name}/*"
         }
+    ]
+}
 EOF
 }


### PR DESCRIPTION
should fix this error:
`aws_s3_bucket.log_bucket: Error putting S3 policy: MalformedPolicy: Policies must be valid JSON and the first byte must be '{'`
from [this build](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/bootstrap-tooling/builds/309)

this matches the format [here](https://github.com/18F/cg-provision/blob/master/terraform/modules/s3_bucket/public_encrypted_bucket/public_encrypted_bucket.tf#L17)