### PR TITLE
Only create log bucket in tooling

### DIFF
--- a/terraform/stacks/main/buckets.tf
+++ b/terraform/stacks/main/buckets.tf
@@ -4,10 +4,3 @@ module "bosh_blobstore_bucket" {
   aws_partition = "${data.aws_partition.current.partition}"
   force_destroy = "true"
 }
-
-module "log_bucket" {
-  source = "../../modules/log_bucket"
-  aws_partition = "${data.aws_partition.current.partition}"
-  log_bucket_name = "${var.log_bucket_name}"
-  aws_region = "${data.aws_region.current.name}"
-}


### PR DESCRIPTION
Terraform gets mad when we declare a bucket in more than one stack, so only do it in tooling