### PR TITLE
make log bucket name available in tf state file

### DIFF
--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -428,7 +428,9 @@ output "etcd_backup_bucket_name" {
 output "bosh_blobstore_bucket" {
   value = "${module.bosh_blobstore_bucket.bucket_name}"
 }
-
+output "elb_log_bucket"{
+  value = "${var.log_bucket_name}"
+}
 output "tooling_bosh_static_ip" {
   value = "${data.terraform_remote_state.target_vpc.tooling_bosh_static_ip}"
 }


### PR DESCRIPTION
This makes the log bucket name available for consumption in the tf state file, so it can be used in the logsearch pipeline