### PR TITLE
explain script

### DIFF
--- a/ci/upload-certificate.sh
+++ b/ci/upload-certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 export AWS_ACCESS_KEY_ID=$(spruce json terraform-yaml-tooling/state.yml | jq -r ".terraform_outputs.iam_cert_provision_access_key_id_curr")
 export AWS_SECRET_ACCESS_KEY=$(spruce json terraform-yaml-tooling/state.yml | jq -r ".terraform_outputs.iam_cert_provision_secret_access_key_curr")


### PR DESCRIPTION
Sometimes, this script fails trying to delete certificates with an AccessDenied error, then succeeds later. This is an effort to log next time this happens so we can troubleshoot why. 