### PR TITLE
add ALBs for new domain broker

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -340,6 +340,7 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.dev.us-gov-west-1.aws-us-gov.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
+      TF_VAR_domain_broker_v2_alb_count: "2"
       TF_VAR_challenge_bucket: development-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/development/*"
       TF_VAR_alb_prefix: "development-domains-*"
@@ -446,6 +447,7 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.fr-stage.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr-stage.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "2"
+      TF_VAR_domain_broker_v2_alb_count: "2"
       TF_VAR_challenge_bucket: staging-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/staging/*"
       TF_VAR_alb_prefix: "staging-domains-*"
@@ -551,6 +553,7 @@ jobs:
       TF_VAR_shibboleth_hosts: '["idp.fr.cloud.gov"]'
       TF_VAR_platform_kibana_hosts: '["logs-platform.fr.cloud.gov"]'
       TF_VAR_domains_broker_alb_count: "3"
+      TF_VAR_domain_broker_v2_alb_count: "3"
       TF_VAR_challenge_bucket: production-domains-broker-challenge
       TF_VAR_iam_cert_prefix: "/domains/production/*"
       TF_VAR_alb_prefix: "production-domains-*"

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -243,7 +243,7 @@ resource "aws_lb_listener" "domain_broker_v2_https" {
   }
 }
 
-resource "aws_lb_listener_rule" "static_http" {
+resource "aws_lb_listener_rule" "domain_broker_v2static_http" {
   count = "${var.domain_broker_v2_alb_count}"
 
   listener_arn = "${aws_lb_listener.domain_broker_v2_http.*.arn[count.index]}"
@@ -259,14 +259,14 @@ resource "aws_lb_listener_rule" "static_http" {
   }
 }
 
-resource "aws_lb_listener_rule" "static_https" {
+resource "aws_lb_listener_rule" "domain_broker_v2_static_https" {
   count = "${var.domain_broker_v2_alb_count}"
 
   listener_arn = "${aws_lb_listener.domain_broker_v2_https.*.arn[count.index]}"
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.domain_broker_challenge.*.arn[count.index]}"
+    target_group_arn = "${aws_lb_target_group.domain_broker_v2_challenge.*.arn[count.index]}"
   }
 
   condition {

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -3,6 +3,9 @@ variable "domains_broker_alb_count" {
 }
 variable "domains_broker_rds_username" {}
 variable "domains_broker_rds_password" {}
+variable "domain_broker_v2_alb_count" {
+  default = 0
+}
 variable "challenge_bucket" {}
 variable "iam_cert_prefix" {
   default = "/domains/*"

--- a/terraform/stacks/main/outputs.tf
+++ b/terraform/stacks/main/outputs.tf
@@ -172,7 +172,9 @@ output "cf_router_target_groups" {
     list("${module.cf.lb_target_group}"),
     list("${module.cf.apps_lb_target_group}"),
     aws_lb_target_group.domains_broker_apps.*.name,
-    aws_lb_target_group.domains_broker_challenge.*.name
+    aws_lb_target_group.domains_broker_challenge.*.name,
+    aws_lb_target_group.domain_broker_v2_apps.*.name,
+    aws_lb_target_group.domain_broker_v2_challenge.*.name
   )}"
 }
 


### PR DESCRIPTION
This adds the new ALBs to our stacks.
Since the new broker is a CF app, it doesn't need a new RDS instance or any of that noise. 