### PR TITLE
change domain broker from cloud.gov hz to cdn-broker-test.cloud.gov

### DIFF
--- a/terraform/stacks/external/stack.tf
+++ b/terraform/stacks/external/stack.tf
@@ -33,8 +33,8 @@ module "lets_encrypt_user" {
 }
 
 module "domain_broker_v2_user" {
-  source = "../../modules/iam_user/lets_encrypt"
+  source = "../../modules/cdn_broker"
   aws_partition = "${data.aws_partition.current.partition}"
-  hosted_zone = "${var.lets_encrypt_hosted_zone}"
-  username = "domain-broker-v2-${var.stack_description}"
+  hosted_zone = "${var.cdn_hosted_zone}"
+  username = "domain-broker-v2"
 }

--- a/terraform/stacks/external/variables.tf
+++ b/terraform/stacks/external/variables.tf
@@ -6,3 +6,5 @@ variable "cdn_broker_hosted_zone" {}
 variable "cdn_broker_bucket" {}
 
 variable "lets_encrypt_hosted_zone" {}
+
+variable "cdn_hosted_zone" {}


### PR DESCRIPTION
This was stuck in a resolving loop, by using the CDN broker hosted zone, I can create test CNAME records, resolving to the ELBs, which send the traffic from the other domain through the platform. This is the proper design, the existing LE design I was using was wrong.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>