### PR TITLE
Reduce timeout for logsearch-platform ELB

### DIFF
--- a/terraform/modules/logsearch/elb_platform_syslog.tf
+++ b/terraform/modules/logsearch/elb_platform_syslog.tf
@@ -2,7 +2,7 @@ resource "aws_elb" "platform_syslog_elb" {
   name = "${var.stack_description}-platform-syslog"
   subnets = ["${var.private_elb_subnets}"]
   security_groups = ["${var.bosh_security_group}"]
-  idle_timeout = 3600
+  idle_timeout = 60
   internal = true
 
   listener {


### PR DESCRIPTION
Currently, one instance of the ingestor seems to get most of the load. The goal here is to force connections to reset more often, allowing more instances to get in on the fun.

I'm not overly-confident this will fix the problem we have, but I'm very confident it won't make anything worse