### PR TITLE
set domain_broker_v2 username based on stack

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -82,7 +82,6 @@ jobs:
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_staging))
       TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_staging))
       TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_staging))
-      TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_staging))
       TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_staging))
   - &notify-slack
     put: slack
@@ -142,7 +141,6 @@ jobs:
       TF_VAR_cdn_broker_hosted_zone: ((cdn_broker_hosted_zone_production))
       TF_VAR_domain_broker_v2_bucket: ((domain_broker_v2_bucket_production))
       TF_VAR_domain_broker_v2_cloudfront_prefix: ((domain_broker_v2_cloudfront_prefix_production))
-      TF_VAR_domain_broker_v2_username: ((domain_broker_v2_username_production))
       TF_VAR_lets_encrypt_hosted_zone: ((lets_encrypt_hosted_zone_production))
   - *notify-slack
 

--- a/terraform/stacks/main/domains_broker.tf
+++ b/terraform/stacks/main/domains_broker.tf
@@ -205,7 +205,7 @@ output "domains_broker_listener_arns" {
 /* new broker ALB */
 
 resource "aws_iam_user" "domain_broker_v2" {
-  name = "domain_broker_v2"
+  name = "domain_broker_v2_${var.stack_description}"
   path = "/domain-broker-v2/"
 }
 


### PR DESCRIPTION
This creates one instance of the domain broker per stack, instead of one shared across stacks. This should fix the "user already exists" problem we're currently running into.
