### PR TITLE
updated concourse worker policy.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -242,6 +242,7 @@ jobs:
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
       TF_VAR_wildcard_staging_certificate_name_prefix: star.fr-stage.cloud.gov
       TF_VAR_wildcard_production_certificate_name_prefix: star.fr.cloud.gov
+      TF_VAR_concourse_varz_bucket: ((concourse_varz_bucket))
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -37,7 +37,9 @@
         "arn:${aws_partition}:s3:::${buildpack_notify_bucket}",
         "arn:${aws_partition}:s3:::${buildpack_notify_bucket}/*",
         "arn:${aws_partition}:s3:::${cg_binaries_bucket}",
-        "arn:${aws_partition}:s3:::${cg_binaries_bucket}/*"
+        "arn:${aws_partition}:s3:::${cg_binaries_bucket}/*",
+        "arn:${aws_partition}:s3:::${concourse_varz_bucket}",
+        "arn:${aws_partition}:s3:::${concourse_varz_bucket}/*"
       ]
     },
     {

--- a/terraform/modules/iam_role_policy/concourse_worker/policy.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.tf
@@ -12,6 +12,7 @@ data "template_file" "policy" {
     billing_bucket = "${var.billing_bucket}"
     cg_binaries_bucket = "${var.cg_binaries_bucket}"
     log_bucket = "${var.log_bucket}"
+    concourse_varz_bucket = "${var.concourse_varz_bucket}"
   }
 }
 

--- a/terraform/modules/iam_role_policy/concourse_worker/variables.tf
+++ b/terraform/modules/iam_role_policy/concourse_worker/variables.tf
@@ -1,6 +1,5 @@
 variable "policy_name" {}
 variable "aws_partition" {}
-
 variable "varz_bucket" {}
 variable "varz_staging_bucket" {}
 variable "bosh_release_bucket" {}
@@ -10,3 +9,4 @@ variable "buildpack_notify_bucket" {}
 variable "billing_bucket" {}
 variable "cg_binaries_bucket" {}
 variable "log_bucket" {}
+variable "concourse_varz_bucket" {}

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -59,6 +59,7 @@ module "concourse_worker_policy" {
   billing_bucket = "${var.billing_bucket}"
   cg_binaries_bucket = "${var.cg_binaries_bucket}"
   log_bucket = "${var.log_bucket_name}"
+  concourse_varz_bucket = "${var.concourse_varz_bucket}"
 }
 
 module "concourse_iaas_worker_policy" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -20,6 +20,8 @@ variable "remote_state_bucket" {}
 variable "concourse_prod_rds_password" {}
 variable "concourse_staging_rds_password" {}
 
+variable "concourse_varz_bucket" {}
+
 variable "wildcard_production_certificate_name_prefix" {
   default = ""
 }


### PR DESCRIPTION
Allowing policy that allows for Concourse to read it's own pipeline credentials.

Reference build: [#1800](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/plan-bootstrap-tooling/builds/1800)

## Security Considerations

Concourse can read but not write credentials from a variable store without an operator having to manually set them in the pipeline. This doesn't change the existing posture, just streamlines the process.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>