### PR TITLE
Tooling/doomsday update

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -244,6 +244,8 @@ jobs:
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
       TF_VAR_wildcard_staging_certificate_name_prefix: star.fr-stage.cloud.gov
       TF_VAR_wildcard_production_certificate_name_prefix: star.fr.cloud.gov
+      TF_VAR_oidc_client: "client"
+      TF_VAR_oidc_client_secret: "something"
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -244,8 +244,8 @@ jobs:
       TF_VAR_nessus_hosts: '["nessus.fr.cloud.gov"]'
       TF_VAR_wildcard_staging_certificate_name_prefix: star.fr-stage.cloud.gov
       TF_VAR_wildcard_production_certificate_name_prefix: star.fr.cloud.gov
-      TF_VAR_oidc_client: "client"
-      TF_VAR_oidc_client_secret: "something"
+      TF_VAR_oidc_client: ((tooling_oidc_client))
+      TF_VAR_oidc_client_secret: ((tooling_oidc_client_secret))
   - *notify-slack
 
 - name: bootstrap-tooling

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -30,3 +30,45 @@ resource "aws_lb_listener_rule" "prometheus_listener_rule" {
     }
   }
 }
+
+resource "aws_lb_target_group" "doomsday_target" {
+  name     = "${var.stack_description}-doomsday"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${var.vpc_id}"
+
+  health_check {
+    healthy_threshold = 2
+    interval = 5
+    path = "/"
+    timeout = 4
+    unhealthy_threshold = 3
+    matcher = 200
+  }
+}
+
+resource "aws_lb_listener_rule" "doomsday_listener_rule" {
+  count = "${length(var.hosts)}"
+
+  listener_arn = "${var.listener_arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.doomsday_target.arn}"
+  }
+
+  authenticate_oidc {
+    # https://opslogin.fr.cloud.gov/.well-known/openid-configuration
+    authorization_endpoint = "https://opslogin.fr.cloud.gov/oauth/authorize"
+    client_id = "${var.oidc-client}"
+    client_secret = "${var.oidc-client-secret}"
+    issuer = "https://opslogin.fr.cloud.gov/oauth/token"
+    token_endpoint = "https://opslogin.fr.cloud.gov/oauth/token"
+    user_info_endpoint = "https://opslogin.fr.cloud.gov/userinfo"
+    on_unauthenticated_request = "authenticate"
+  }
+
+  condition {
+    host_header = "doomsday*"
+  }
+}

--- a/terraform/modules/monitoring/elb.tf
+++ b/terraform/modules/monitoring/elb.tf
@@ -71,7 +71,7 @@ resource "aws_lb_listener_rule" "doomsday_listener_rule" {
 
   condition {
     host_header {
-      value = ["doomsday.fr*.cloud.gov"]
+      values = ["doomsday.fr*.cloud.gov"]
     }
   }
 }

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -17,3 +17,7 @@ variable "listener_arn" {}
 variable "hosts" {
   type = "list"
 }
+
+variable "oidc-client" {}
+
+variable "oidc-client-secret" {}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -18,6 +18,6 @@ variable "hosts" {
   type = "list"
 }
 
-variable "oidc-client" {}
+variable "oidc_client" {}
 
-variable "oidc-client-secret" {}
+variable "oidc_client_secret" {}

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -455,6 +455,28 @@ resource "aws_route53_record" "cloud_gov_grafana_fr_cloud_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "cloud_gov_doomsday_fr_cloud_gov_a" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "doomsday.fr.cloud.gov."
+  type = "A"
+  alias {
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
+    zone_id = "${var.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_doomsday_fr_cloud_gov_aaaa" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "doomsday.fr.cloud.gov."
+  type = "AAAA"
+  alias {
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
+    zone_id = "${var.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 /* Platform logs */
 
 resource "aws_route53_record" "cloud_gov_logs_platform_dev_env_a" {

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -227,6 +227,28 @@ resource "aws_route53_record" "cloud_gov_grafana_fr-stage_cloud_gov_aaaa" {
   }
 }
 
+resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_a" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "doomsday.fr-stage.cloud.gov."
+  type = "A"
+  alias {
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
+    zone_id = "${var.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cloud_gov_doomsday_fr-stage_cloud_gov_aaaa" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "doomsday.fr-stage.cloud.gov."
+  type = "AAAA"
+  alias {
+    name = "dualstack.${data.terraform_remote_state.tooling.main_lb_dns_name}"
+    zone_id = "${var.cloudfront_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "cloud_gov_ssh_fr-stage_cloud_gov_a" {
   zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
   name = "ssh.fr-stage.cloud.gov."

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -125,6 +125,8 @@ module "monitoring_production" {
   route_table_id = "${module.stack.private_route_table_az1}"
   listener_arn = "${aws_lb_listener.main.arn}"
   hosts = ["${var.monitoring_production_hosts}"]
+  oidc_client = "${var.oidc_client}"
+  oidc_client_secret = "${var.oidc_client_secret}"
 }
 
 module "monitoring_staging" {
@@ -136,6 +138,8 @@ module "monitoring_staging" {
   route_table_id = "${module.stack.private_route_table_az2}"
   listener_arn = "${aws_lb_listener.main.arn}"
   hosts = ["${var.monitoring_staging_hosts}"]
+  oidc_client = "${var.oidc_client}"
+  oidc_client_secret = "${var.oidc_client_secret}"
 }
 
 resource "aws_eip" "production_dns_eip" {

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -110,3 +110,7 @@ variable "cloudtrail_bucket" {
 variable "log_bucket_name" {
   default = "cg-elb-logs"
 }
+
+variable "oidc-client" {}
+
+variable "oidc-client-secret" {}

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -111,6 +111,6 @@ variable "log_bucket_name" {
   default = "cg-elb-logs"
 }
 
-variable "oidc-client" {}
+variable "oidc_client" {}
 
-variable "oidc-client-secret" {}
+variable "oidc_client_secret" {}


### PR DESCRIPTION
This adds an internal listener, DNS entry, and OIDC configuration in tooling for Doomsday so it can be functional like Prometheus or Grafana. I put it's code in with the monitoring stuff since it seemed like the right place to put it.

Successful Build: [#1835](https://ci.fr.cloud.gov/teams/main/pipelines/terraform-provision/jobs/plan-bootstrap-tooling/builds/1835)

## Security Considerations

This authentication flow is a bit different as the authentication would be handled by the ELB instead of by an OAuth2 proxy.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>