### PR TITLE
tooling: added doomsday target group for vm extension.

### DIFF
--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -18,3 +18,7 @@ output "lb_target_group" {
   value = "${aws_lb_target_group.prometheus_target.name}"
 }
 
+# doomsday lb target.
+output "doomsday_lb_target_group" {
+  value = "${aws_lb_target_group.doomsday_target.name}"
+}


### PR DESCRIPTION
Added separate output for doomsday LB group since it was being overridden by the prometheus group.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>