### PR TITLE
tooling: added doomsday output mappings.

### DIFF
--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -340,6 +340,10 @@ output "production_monitoring_lb_target_group" {
   value = "${module.monitoring_production.lb_target_group}"
 }
 
+output "production_doomsday_lb_target_group" {
+  value = "${module.monitoring_production.doomsday_lb_target_group}"
+}
+
 output "monitoring_security_groups" {
   value = {
     staging = "${module.monitoring_staging.monitoring_security_group}"
@@ -360,6 +364,10 @@ output "staging_monitoring_security_group" {
 }
 output "staging_monitoring_lb_target_group" {
   value = "${module.monitoring_staging.lb_target_group}"
+}
+
+output "staging_doomsday_lb_target_group" {
+  value = "${module.monitoring_production.doomsday_lb_target_group}"
 }
 
 /* billing user */

--- a/terraform/stacks/tooling/outputs.tf
+++ b/terraform/stacks/tooling/outputs.tf
@@ -367,7 +367,7 @@ output "staging_monitoring_lb_target_group" {
 }
 
 output "staging_doomsday_lb_target_group" {
-  value = "${module.monitoring_production.doomsday_lb_target_group}"
+  value = "${module.monitoring_staging.doomsday_lb_target_group}"
 }
 
 /* billing user */


### PR DESCRIPTION
This should properly map the doomsday outputs now.

## Security Considerations

None.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>