### PR TITLE
Add SPF record and Google verification TXT records

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -95,8 +95,10 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
   name = "cloud.gov."
   type = "TXT"
   ttl = 300
-  records = ["v=spf1 -all"]
-
+  records = [
+    "v=spf1 include:mail.zendesk.com ?all",
+    "google-site-verification=JlbE7awT0VhzUvlXbc1wO1yhfFme3lSE1ViUmFX6EEY"
+  ]
 }
 
 resource "aws_route53_record" "cloud_gov_2a37e22b1f41ad3fe6af39f4fc38c1bc_cloud_gov_cname" {


### PR DESCRIPTION
- add spf record to be able to send email from zendesk. You can learn more about this setting on the [zendesk documention](https://support.zendesk.com/hc/en-us/articles/203683886-Allowing-Zendesk-to-send-email-on-behalf-of-your-email-domain#topic_g5q_s42_vp)
- add google verification so we can use [Google Search Console](https://search.google.com/search-console/about) to manage search traffic. Will be used by redesign folks.