### PR TITLE
Add cloudtrail auditor for reading Federalist S3 bucket events.

### DIFF
--- a/terraform/modules/iam_user/federalist_auditor/outputs.tf
+++ b/terraform/modules/iam_user/federalist_auditor/outputs.tf
@@ -1,0 +1,15 @@
+output "username" {
+  value = "${var.username}"
+}
+output "access_key_id_prev" {
+  value = ""
+}
+output "secret_access_key_prev" {
+  value = ""
+}
+output "access_key_id_curr" {
+  value = "${aws_iam_access_key.iam_access_key_v3.id}"
+}
+output "secret_access_key_curr" {
+  value = "${aws_iam_access_key.iam_access_key_v3.secret}"
+}

--- a/terraform/modules/iam_user/federalist_auditor/policy.json
+++ b/terraform/modules/iam_user/federalist_auditor/policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudtrail:LookupEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/modules/iam_user/federalist_auditor/user.tf
+++ b/terraform/modules/iam_user/federalist_auditor/user.tf
@@ -1,0 +1,22 @@
+# This user has access to all cloudtrail events in the account, as there
+# doesn't seem to be a way of constraining to just cloudfront events relevant
+# to a set of S3 buckets (or all S3 buckets, for that matter).
+#
+# If you need cloudtrail auditor access for another reason, PLEASE CREATE A NEW
+# USER AND MODULE (yes, even with the same permissions).  Having separate users
+# with the same permissions simplifies our work when we have to rotate
+# credentials.
+
+resource "aws_iam_user" "iam_user" {
+  name = "${var.username}"
+}
+
+resource "aws_iam_access_key" "iam_access_key_v3" {
+  user = "${aws_iam_user.iam_user.name}"
+}
+
+resource "aws_iam_user_policy" "iam_policy" {
+  name = "${aws_iam_user.iam_user.name}-policy"
+  user = "${aws_iam_user.iam_user.name}"
+  policy = "${file("${path.module}/policy.json")}"
+}

--- a/terraform/modules/iam_user/federalist_auditor/variables.tf
+++ b/terraform/modules/iam_user/federalist_auditor/variables.tf
@@ -1,0 +1,1 @@
+variable "username" {}

--- a/terraform/stacks/main/iam.tf
+++ b/terraform/stacks/main/iam.tf
@@ -287,3 +287,17 @@ module "kubernetes_logger_role" {
   minion_role = "${module.kubernetes_minion_role.role_name}"
   assume_role_path = "/bosh-passed/"
 }
+
+# This user has access to all cloudtrail events in the account, as there
+# doesn't seem to be a way of constraining to just cloudfront events relevant
+# to a set of S3 buckets (or all S3 buckets, for that matter).
+#
+# If you need cloudtrail auditor access for another reason, PLEASE CREATE A NEW
+# USER AND MODULE (yes, even with the same permissions).  Having separate users
+# with the same permissions simplifies our work when we have to rotate
+# credentials.
+module "federalist_auditor_user" {
+  source = "../../modules/iam_user/federalist_auditor"
+  username = "federalist-s3-bucket-auditor"
+}
+


### PR DESCRIPTION
This adds an IAM user that can read CloudTrail events, to be used by the federalist auditor user, required to finish this issue: https://github.com/18F/cg-product/issues/1192

#### Security Considerations:

While the intended use is to read CloudTrail events from a particular set of buckets, the IAM User Policy actually allows access to all events across the account.  We cannot determine a good way of limiting further.