### PR TITLE
set new cloudfront URL provided by federalist

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -73,7 +73,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_a" {
   name = "cloud.gov."
   type = "A"
   alias {
-    name = "d2vy872d33xc5d.cloudfront.net."
+    name = "daujy4orocwma.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
@@ -84,7 +84,7 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_aaaa" {
   name = "cloud.gov."
   type = "AAAA"
   alias {
-    name = "d2vy872d33xc5d.cloudfront.net."
+    name = "daujy4orocwma.cloudfront.net."
     zone_id = "Z2FDTNDATAQYW2"
     evaluate_target_health = false
   }
@@ -108,6 +108,16 @@ resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
   ttl = 300
   records = [
     "bb924f6a32697b2b"
+  ]
+}
+
+resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "_acme-challenge.cloud.gov."
+  type = "TXT"
+  ttl = 120
+  records = [
+    "StvL8Z97d63ziair8f7Npo-TrfkkrB0eG3xa3uxG0Zo"
   ]
 }
 
@@ -769,7 +779,7 @@ resource "aws_route53_record" "cloud_gov_www_cloud_gov_cname" {
   name = "www.cloud.gov."
   type = "CNAME"
   ttl = 60
-  records = ["d2vy872d33xc5d.cloudfront.net."]
+  records = ["daujy4orocwma.cloudfront.net."]
 }
 
 resource "aws_route53_record" "cdn_broker_delegate" {

--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -111,7 +111,7 @@ resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
   ]
 }
 
-resource "aws_route53_record" "cloud_gov_zendesk_verification_txt" {
+resource "aws_route53_record" "cloud_gov_federalist_verification_txt" {
   zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
   name = "_acme-challenge.cloud.gov."
   type = "TXT"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Will point the main cg-site to cloudfront URL managed by federalist.
- URL is here: daujy4orocwma.cloudfront.net
- But first https://github.com/18F/cg-site/pull/1503 must be merged to assets load properly.
- Preview new site here: https://cg-88d42ca6-59d7-47e0-9500-4dd9251360b9.app.cloud.gov/site/18f/cg-site/

## security considerations
None