### PR TITLE
create zendesk url

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -115,6 +115,14 @@ resource "aws_route53_record" "cloud_gov_cloud_gov_txt" {
   ]
 }
 
+resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
+  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
+  name = "support.cloud.gov."
+  type = "CNAME"
+  ttl = 60
+  records = ["cloud-gov.zendesk.com."]
+}
+
 
 resource "aws_route53_record" "cloud_gov_gsuite_dkim_txt" {
   zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add support.cloud.gov to point to zendesk
- Be less reliant on external URLs so if we need to change service providers, we don't break links.

## security considerations
- None. 