### PR TITLE
remove acme-challenge record since we have solved the challenge

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -68,17 +68,6 @@ resource "aws_route53_zone" "cloud_gov_zone" {
   }
 }
 
-
-resource "aws_route53_record" "acme_challenge_www_cloud_gov_cloud_gov_txt" {
-  zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
-  name = "_acme-challenge.www.cloud.gov"
-  type = "TXT"
-  ttl = 300
-  records = [
-    "Ks4AnY9CZQLOo-btH-pWUYxpKxcH8mW-U4o394n8OYE"
-  ]
-
-}
 resource "aws_route53_record" "cloud_gov_cloud_gov_a" {
   zone_id = "${aws_route53_zone.cloud_gov_zone.zone_id}"
   name = "cloud.gov."


### PR DESCRIPTION
## Changes proposed in this pull request:
- Delete the acme-challenge record. We've solved the challenge, so the broker will handle renewals with http-01 going forward

## security considerations
none