### PR TITLE
Allow RDS to be upgraded immediately

### DIFF
--- a/terraform/modules/rds/database.tf
+++ b/terraform/modules/rds/database.tf
@@ -34,6 +34,8 @@ resource "aws_db_instance" "rds_database" {
     "${join("", aws_db_parameter_group.parameter_group_postgres.*.id)}" :
     "${join("", aws_db_parameter_group.parameter_group_mysql.*.id)}"}"
 
+  allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
+  apply_immediately = "${var.apply_immediately}"
   tags {
     Name = "${var.stack_description}"
   }

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -55,3 +55,11 @@ variable "rds_multi_az" {
 variable "rds_final_snapshot_identifier" {
   default = ""
 }
+
+variable "apply_immediately" {
+  default = "false"
+}
+
+variable "allow_major_version_upgrade" {
+  default = "false"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds the following variables to the RDS module
- `allow_major_version_upgrade`
- `apply_immediately`

Together, they allow RDS instances to be upgraded immediately.   These should be used in a three-phase apply:

1. Set both to `true` and apply the configuration.
1. Upgrade the DB version and apply
1. Set both to `false` and apply.


## security considerations
None.
