### PR TITLE
Create `cg-build-artifacts` bucket for use in concourse pipelines

### DIFF
--- a/terraform/modules/iam_role_policy/concourse_worker/policy.json
+++ b/terraform/modules/iam_role_policy/concourse_worker/policy.json
@@ -38,6 +38,8 @@
         "arn:${aws_partition}:s3:::${buildpack_notify_bucket}/*",
         "arn:${aws_partition}:s3:::${cg_binaries_bucket}",
         "arn:${aws_partition}:s3:::${cg_binaries_bucket}/*",
+        "arn:${aws_partition}:s3:::${build_artifacts_bucket}",
+        "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}",
         "arn:${aws_partition}:s3:::${concourse_varz_bucket}/*"
       ]
@@ -59,6 +61,7 @@
         "arn:${aws_partition}:s3:::${billing_bucket}",
         "arn:${aws_partition}:s3:::${billing_bucket}/*",
         "arn:${aws_partition}:s3:::${varz_bucket}/master-bosh-state.json",
+        "arn:${aws_partition}:s3:::${build_artifacts_bucket}/*",
         "arn:${aws_partition}:s3:::${terraform_state_bucket}/*"
       ]
     }

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -52,7 +52,7 @@ module "log_bucket" {
   aws_region      = "${data.aws_region.current.name}"
 }
 
-module "billing_bucket_staging" {
+module "build_artifacts_bucket" {
   source        = "../../modules/s3_bucket/encrypted_bucket"
   bucket        = "${var.bucket_prefix}build-artifacts"
   aws_partition = "${data.aws_partition.current.partition}"

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -1,53 +1,59 @@
 module "bosh_blobstore_bucket" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.blobstore_bucket_name}"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.blobstore_bucket_name}"
   aws_partition = "${data.aws_partition.current.partition}"
   force_destroy = "true"
 }
 
 module "bosh_release_bucket" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bosh_release_bucket}"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bosh_release_bucket}"
   aws_partition = "${data.aws_partition.current.partition}"
-  versioning = "true"
+  versioning    = "true"
   force_destroy = "true"
 }
 
 module "billing_bucket_staging" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bucket_prefix}cg-billing-staging"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}cg-billing-staging"
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
 module "billing_bucket_production" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bucket_prefix}cg-billing-production"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}cg-billing-production"
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
 module "buildpack_notify_state_staging" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bucket_prefix}buildpack-notify-state-staging"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}buildpack-notify-state-staging"
   aws_partition = "${data.aws_partition.current.partition}"
-  versioning = "true"
+  versioning    = "true"
 }
 
 module "buildpack_notify_state_production" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bucket_prefix}buildpack-notify-state-production"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}buildpack-notify-state-production"
   aws_partition = "${data.aws_partition.current.partition}"
-  versioning = "true"
+  versioning    = "true"
 }
 
 module "cg_binaries_bucket" {
-  source = "../../modules/s3_bucket/encrypted_bucket"
-  bucket = "${var.bucket_prefix}cg-binaries"
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}cg-binaries"
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
 module "log_bucket" {
-  source = "../../modules/log_bucket"
-  aws_partition = "${data.aws_partition.current.partition}"
+  source          = "../../modules/log_bucket"
+  aws_partition   = "${data.aws_partition.current.partition}"
   log_bucket_name = "${var.log_bucket_name}"
-  aws_region = "${data.aws_region.current.name}"
+  aws_region      = "${data.aws_region.current.name}"
+}
+
+module "billing_bucket_staging" {
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "${var.bucket_prefix}build-artifacts"
+  aws_partition = "${data.aws_partition.current.partition}"
 }

--- a/terraform/stacks/tooling/iam.tf
+++ b/terraform/stacks/tooling/iam.tf
@@ -1,27 +1,27 @@
 module "billing_user" {
-  source = "../../modules/iam_user/billing_user"
-  username = "cg-billing"
+  source         = "../../modules/iam_user/billing_user"
+  username       = "cg-billing"
   billing_bucket = "cg-billing-*"
-  aws_partition = "${data.aws_partition.current.partition}"
+  aws_partition  = "${data.aws_partition.current.partition}"
 }
 
 module "s3_logstash" {
-  source = "../../modules/iam_user/s3_logstash"
-  username = "s3-logstash"
-  log_bucket = "${var.log_bucket_name}"
+  source        = "../../modules/iam_user/s3_logstash"
+  username      = "s3-logstash"
+  log_bucket    = "${var.log_bucket_name}"
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
 module "rds_storage_alert" {
-  source = "../../modules/iam_user/rds_storage_alert"
+  source   = "../../modules/iam_user/rds_storage_alert"
   username = "cg-rds-storage-alert"
 }
 
 module "iam_cert_provision_user" {
-  source = "../../modules/iam_user/iam_cert_provision"
-  username = "cg-iam-cert-provision"
+  source        = "../../modules/iam_user/iam_cert_provision"
+  username      = "cg-iam-cert-provision"
   aws_partition = "${data.aws_partition.current.partition}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
+  account_id    = "${data.aws_caller_identity.current.account_id}"
 }
 
 # This user has access to all cloudtrail events in the account, as there
@@ -33,146 +33,153 @@ module "iam_cert_provision_user" {
 # with the same permissions simplifies our work when we have to rotate
 # credentials.
 module "federalist_auditor_user" {
-  source = "../../modules/iam_user/federalist_auditor"
+  source   = "../../modules/iam_user/federalist_auditor"
   username = "federalist-s3-bucket-auditor"
 }
 
 module "blobstore_policy" {
-  source = "../../modules/iam_role_policy/blobstore"
-  policy_name = "blobstore"
+  source        = "../../modules/iam_role_policy/blobstore"
+  policy_name   = "blobstore"
   aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  bucket_name   = "${var.blobstore_bucket_name}"
 }
 
 module "bosh_policy" {
-  source = "../../modules/iam_role_policy/bosh"
-  policy_name = "${var.stack_description}-bosh"
+  source        = "../../modules/iam_role_policy/bosh"
+  policy_name   = "${var.stack_description}-bosh"
   aws_partition = "${data.aws_partition.current.partition}"
-  account_id = "${data.aws_caller_identity.current.account_id}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  account_id    = "${data.aws_caller_identity.current.account_id}"
+  bucket_name   = "${var.blobstore_bucket_name}"
 }
 
 module "bosh_compilation_policy" {
-  source = "../../modules/iam_role_policy/bosh_compilation"
-  policy_name = "${var.stack_description}-bosh-compilation"
+  source        = "../../modules/iam_role_policy/bosh_compilation"
+  policy_name   = "${var.stack_description}-bosh-compilation"
   aws_partition = "${data.aws_partition.current.partition}"
-  bucket_name = "${var.blobstore_bucket_name}"
+  bucket_name   = "${var.blobstore_bucket_name}"
 }
 
 module "concourse_worker_policy" {
-  source = "../../modules/iam_role_policy/concourse_worker"
-  policy_name = "concourse-worker"
-  aws_partition = "${data.aws_partition.current.partition}"
-  varz_bucket = "${var.varz_bucket}"
-  varz_staging_bucket = "${var.varz_bucket_stage}"
-  bosh_release_bucket = "${var.bosh_release_bucket}"
-  terraform_state_bucket = "${var.terraform_state_bucket}"
-  semver_bucket = "${var.semver_bucket}"
+  source                  = "../../modules/iam_role_policy/concourse_worker"
+  policy_name             = "concourse-worker"
+  aws_partition           = "${data.aws_partition.current.partition}"
+  varz_bucket             = "${var.varz_bucket}"
+  varz_staging_bucket     = "${var.varz_bucket_stage}"
+  bosh_release_bucket     = "${var.bosh_release_bucket}"
+  terraform_state_bucket  = "${var.terraform_state_bucket}"
+  build_artifacts_bucket  = "${var.build_artifacts_bucket}"
+  semver_bucket           = "${var.semver_bucket}"
   buildpack_notify_bucket = "${var.buildpack_notify_bucket}"
-  billing_bucket = "${var.billing_bucket}"
-  cg_binaries_bucket = "${var.cg_binaries_bucket}"
-  log_bucket = "${var.log_bucket_name}"
-  concourse_varz_bucket = "${var.concourse_varz_bucket}"
+  billing_bucket          = "${var.billing_bucket}"
+  cg_binaries_bucket      = "${var.cg_binaries_bucket}"
+  log_bucket              = "${var.log_bucket_name}"
+  concourse_varz_bucket   = "${var.concourse_varz_bucket}"
 }
 
 module "concourse_iaas_worker_policy" {
-  source = "../../modules/iam_role_policy/concourse_iaas_worker"
+  source      = "../../modules/iam_role_policy/concourse_iaas_worker"
   policy_name = "concourse-iaas-worker"
 }
 
 module "cloudwatch_policy" {
-  source = "../../modules/iam_role_policy/cloudwatch"
+  source      = "../../modules/iam_role_policy/cloudwatch"
   policy_name = "${var.stack_description}-cloudwatch"
 }
 
 module "self_managed_mfa" {
-  source = "../../modules/iam_role_policy/self_managed_mfa"
-  policy_name = "self-managed-mfa"
+  source        = "../../modules/iam_role_policy/self_managed_mfa"
+  policy_name   = "self-managed-mfa"
   aws_partition = "${data.aws_partition.current.partition}"
 }
 
 module "default_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-default"
 }
 
 module "master_bosh_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "master-bosh"
 }
 
 module "bosh_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-bosh"
 }
 
 module "bosh_compilation_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "${var.stack_description}-bosh-compilation"
 }
 
 module "concourse_worker_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "tooling-concourse-worker"
 }
 
 module "concourse_iaas_worker_role" {
-  source = "../../modules/iam_role"
+  source    = "../../modules/iam_role"
   role_name = "tooling-concourse-iaas-worker"
 }
 
 resource "aws_iam_policy_attachment" "blobstore" {
-  name = "${var.stack_description}-blobstore"
+  name       = "${var.stack_description}-blobstore"
   policy_arn = "${module.blobstore_policy.arn}"
+
   roles = [
     "${module.default_role.role_name}",
     "${module.bosh_role.role_name}",
     "${module.concourse_worker_role.role_name}",
-    "${module.concourse_iaas_worker_role.role_name}"
+    "${module.concourse_iaas_worker_role.role_name}",
   ]
 }
 
 resource "aws_iam_policy_attachment" "cloudwatch" {
-  name = "${var.stack_description}-cloudwatch"
+  name       = "${var.stack_description}-cloudwatch"
   policy_arn = "${module.cloudwatch_policy.arn}"
+
   roles = [
     "${module.default_role.role_name}",
     "${module.bosh_role.role_name}",
     "${module.bosh_compilation_role.role_name}",
     "${module.concourse_worker_role.role_name}",
-    "${module.concourse_iaas_worker_role.role_name}"
+    "${module.concourse_iaas_worker_role.role_name}",
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh" {
-  name = "${var.stack_description}-bosh"
+  name       = "${var.stack_description}-bosh"
   policy_arn = "${module.bosh_policy.arn}"
+
   roles = [
     "${module.master_bosh_role.role_name}",
-    "${module.bosh_role.role_name}"
+    "${module.bosh_role.role_name}",
   ]
 }
 
 resource "aws_iam_policy_attachment" "bosh_compilation" {
-  name = "${var.stack_description}-bosh-compilation"
+  name       = "${var.stack_description}-bosh-compilation"
   policy_arn = "${module.bosh_compilation_policy.arn}"
+
   roles = [
-    "${module.bosh_compilation_role.role_name}"
+    "${module.bosh_compilation_role.role_name}",
   ]
 }
 
 resource "aws_iam_policy_attachment" "concourse_worker" {
-  name = "concourse_worker"
+  name       = "concourse_worker"
   policy_arn = "${module.concourse_worker_policy.arn}"
+
   roles = [
-    "${module.concourse_worker_role.role_name}"
+    "${module.concourse_worker_role.role_name}",
   ]
 }
 
 resource "aws_iam_policy_attachment" "concourse_iaas_worker" {
-  name = "concourse_iaas_worker"
+  name       = "concourse_iaas_worker"
   policy_arn = "${module.concourse_iaas_worker_policy.arn}"
+
   roles = [
-    "${module.concourse_iaas_worker_role.role_name}"
+    "${module.concourse_iaas_worker_role.role_name}",
   ]
 }

--- a/terraform/stacks/tooling/variables.tf
+++ b/terraform/stacks/tooling/variables.tf
@@ -25,6 +25,7 @@ variable "concourse_varz_bucket" {}
 variable "wildcard_production_certificate_name_prefix" {
   default = ""
 }
+
 variable "wildcard_staging_certificate_name_prefix" {
   default = ""
 }
@@ -32,6 +33,7 @@ variable "wildcard_staging_certificate_name_prefix" {
 variable "concourse_production_hosts" {
   type = "list"
 }
+
 variable "concourse_staging_hosts" {
   type = "list"
 }
@@ -39,6 +41,7 @@ variable "concourse_staging_hosts" {
 variable "monitoring_production_hosts" {
   type = "list"
 }
+
 variable "monitoring_staging_hosts" {
   type = "list"
 }
@@ -89,6 +92,10 @@ variable "semver_bucket" {
   default = "cg-semver"
 }
 
+variable "build_artifacts_bucket" {
+  default = "cg-build-artifacts"
+}
+
 variable "buildpack_notify_bucket" {
   default = "buildpack-notify-state-*"
 }
@@ -98,7 +105,7 @@ variable "billing_bucket" {
 }
 
 variable "cg_binaries_bucket" {
-   default = "cg-binaries"
+  default = "cg-binaries"
 }
 
 variable "smtp_ingress_cidr_blocks" {


### PR DESCRIPTION
## Changes proposed in this pull request:

Add a `cg-build-artifacts` bucket for use in concourse pipelines.  This bucket allows us to throw cached assets in s3 that are created early in the pipeline, but required later during deploy.  A good example is the output from `node build`.

## security considerations

Concourse workers have read/write access to this bucket.  This is in line with our other buckets.

