### PR TITLE
Don't create foreign key, since it fails

### DIFF
--- a/ci/scripts/create-and-update-db.sh
+++ b/ci/scripts/create-and-update-db.sh
@@ -61,13 +61,6 @@ for db in ${DATABASES}; do
           seed varchar(36),
           backup_code varchar(36)
         );
-      ALTER TABLE IF EXISTS totp_seed
-        DROP CONSTRAINT IF EXISTS username_record_keeper;
-      ALTER TABLE IF EXISTS totp_seed
-        ADD CONSTRAINT username_record_keeper
-          FOREIGN KEY (username)
-          REFERENCES users (username)
-          ON DELETE CASCADE;
     COMMIT;
 EOT
 


### PR DESCRIPTION
For some reason, username is not unique in uaadb, causing the fkey relationship from totp_seed to fail. Skip creating this constraint so the table will create.

I poked around the existing databases, and this matches reality.

## Changes proposed in this pull request:
- Skip creating a foreign key on totp_seed.username

## security considerations
None