### PR TITLE
adding dev uaa elb records for testing

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -963,7 +963,7 @@ resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
   }
 }
 
-resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
+resource "aws_route53_record" "cloud_gov_uaa_dev_env_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
@@ -974,7 +974,7 @@ resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
     evaluate_target_health = false
   }
 }
-resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
+resource "aws_route53_record" "cloud_gov_uaa_dev_env_aaaa" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "uaa.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"
@@ -986,7 +986,7 @@ resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
   }
 }
 
-resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
+resource "aws_route53_record" "cloud_gov_login_dev_env_a" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "A"
@@ -997,7 +997,7 @@ resource "aws_route53_record" "cloud_gov_star_dev_env_a" {
     evaluate_target_health = false
   }
 }
-resource "aws_route53_record" "cloud_gov_star_dev_env_aaaa" {
+resource "aws_route53_record" "cloud_gov_login_dev_env_aaaa" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "login.dev.us-gov-west-1.aws-us-gov.cloud.gov."
   type    = "AAAA"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding in records for uaa.dev and login.dev dns records for testing dev changes
- For now these records still point to the cf main elb

## security considerations
by moving uaa to it's own elb with dns records CG will have better control over protecting uaa and isolating customer app flow from login based attacks
