### PR TITLE
testing moving uaa/login records to uaa elb in dev

### DIFF
--- a/terraform/stacks/dns/stack.tf
+++ b/terraform/stacks/dns/stack.tf
@@ -969,7 +969,7 @@ resource "aws_route53_record" "cloud_gov_uaa_dev_env_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -980,7 +980,7 @@ resource "aws_route53_record" "cloud_gov_uaa_dev_env_aaaa" {
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -992,7 +992,7 @@ resource "aws_route53_record" "cloud_gov_login_dev_env_a" {
   type    = "A"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }
@@ -1003,7 +1003,7 @@ resource "aws_route53_record" "cloud_gov_login_dev_env_aaaa" {
   type    = "AAAA"
 
   alias {
-    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_lb_dns_name}"
+    name                   = "dualstack.${data.terraform_remote_state.development.outputs.cf_uaa_lb_dns_name}"
     zone_id                = var.cloudfront_zone_id
     evaluate_target_health = false
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- test moving dev uaa/login records over to the uaa elb


## security considerations
by moving uaa to it's own elb with dns records CG will have better control over protecting uaa and isolating customer app flow from login based attacks
