### PR TITLE
add config for cvd mirror bucket

### DIFF
--- a/terraform/modules/cvd_mirror/public_encrypted_bucket.tf
+++ b/terraform/modules/cvd_mirror/public_encrypted_bucket.tf
@@ -1,0 +1,54 @@
+resource "aws_s3_bucket" "cvd_bucket" {
+  bucket        = var.bucket
+  force_destroy = var.force_destroy
+}
+resource "aws_s3_bucket_server_side_encryption_configuration" "public_encrypted_bucket_sse_config" {
+  bucket = aws_s3_bucket.cvd_bucket.id
+  rule {
+    apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+    }
+  }
+}
+resource "aws_s3_bucket_website_configuration" "bucket_website_configuration" {
+  bucket = aws_s3_bucket.cvd_bucket.id
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_policy" "public_encrypted_bucket_policy" {
+  bucket = aws_s3_bucket.cvd_bucket.id
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowRead",
+            "Effect": "Allow",
+            "Principal": {
+                "*"
+            },
+            "Action": "s3:GetObject",
+            "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*"
+        },
+        {
+            "Sid": "DenyUnencryptedPut",
+            "Effect": "Deny",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:${var.aws_partition}:s3:::${var.bucket}/*",
+            "Condition": {
+                "StringNotEquals": {
+                    "s3:x-amz-server-side-encryption": "AES256"
+                }
+            }
+        }
+    ]
+}
+EOF
+
+}
+

--- a/terraform/modules/cvd_mirror/variables.tf
+++ b/terraform/modules/cvd_mirror/variables.tf
@@ -1,0 +1,14 @@
+variable "bucket" {
+}
+
+variable "versioning" {
+  default = "false"
+}
+
+variable "force_destroy" {
+  default = "false"
+}
+
+variable "aws_partition" {
+}
+

--- a/terraform/modules/cvd_mirror/versions.tf
+++ b/terraform/modules/cvd_mirror/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">=4.4.0"
+    }
+  }
+}

--- a/terraform/stacks/tooling/buckets.tf
+++ b/terraform/stacks/tooling/buckets.tf
@@ -59,3 +59,16 @@ module "build_artifacts_bucket" {
   versioning    = "true"
 }
 
+module "cvd_meta_bucket" {
+  source        = "../../modules/s3_bucket/encrypted_bucket"
+  bucket        = "cg-clamav-meta"
+  aws_partition = data.aws_partition.current.partition
+  versioning    = "true"
+}
+
+module "cvd_database_bucket" {
+  source        = "../../modules/cvd_mirror"
+  bucket        = "cg-clamav-mirror"
+  aws_partition = data.aws_partition.current.partition
+  versioning    = "false"
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- add config for cvd mirror bucket


## security considerations
Keeping a clamav mirror means we are less likely to encounter clamav database unavailability in the future