### PR TITLE
Fix TF deployment error

### DIFF
--- a/terraform/stacks/cloudfront/stack.tf
+++ b/terraform/stacks/cloudfront/stack.tf
@@ -3,7 +3,7 @@ terraform {
   }
 
   required_version = ">= 0.15"
-  
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
## Changes proposed in this pull request:

As of Terraform AWS provider 5.48.0, we started getting this error:

```
Invalid Configuration: FIPS and custom endpoint are not supported
```

To fix, pinning the AWS provider to `< 5.48.0` in `stacks/cloudfront` where the deployment error is occurring 

## security considerations

None, just fixing a TF deployment error
