### PR TITLE
Make rds.force_ssl parameter dynamic

### DIFF
--- a/terraform/modules/rds/parameter_group.tf
+++ b/terraform/modules/rds/parameter_group.tf
@@ -29,7 +29,7 @@ resource "aws_db_parameter_group" "parameter_group_postgres" {
   }
 
   dynamic "parameter" {
-    for_each = contains(["postgres15"], var.rds_parameter_group_family) ? [] : [1]
+    for_each = contains(["postgres15", "postgres16"], var.rds_parameter_group_family) ? [] : [1]
     content {
       name         = "rds.force_ssl"
       value        = var.rds_force_ssl


### PR DESCRIPTION
## Changes proposed in this pull request:

There is a TF bug where changes are always detected on the `rds.force_ssl` parameter if it set to `1` for a parameter group family where that value already defaults to `1` (e.g. `postgres15` ,`postgres16`): https://github.com/hashicorp/terraform-provider-aws/issues/23335.

A temporary fix is to make this parameter dynamic so that it does not get set in TF when the parameter group family already has `rds:force_ssl = 1` as a default, which for PostgreSQL is `postgres15` and `postgres16` currently.

This PR applies the temporary fix so that `terraform plan` is not constantly telling us that the parameter is changing, when it is not.

## security considerations

No security implications, since the conditions where `rds.force_ssl = 1` are not changing. We're just refactoring the Terraform so that we don't get inaccurate output from `terraform plan` 
