### PR TITLE
add ListCachePolicies and ListOriginRequestPolicies permissions to external-domain-broker

### DIFF
--- a/terraform/modules/external_domain_broker/iam.tf
+++ b/terraform/modules/external_domain_broker/iam.tf
@@ -84,6 +84,23 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
     }
   }
 
+  # These actions require "*" as the resource constraint.
+  # See https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazoncloudfront.html
+  statement {
+    actions = [
+      "cloudfront:ListCachePolicies",
+      "cloudfront:ListOriginRequestPolicies"
+    ]
+    resources = [
+      "*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
   statement {
     actions = [
       "route53:GetChange"


### PR DESCRIPTION
## Changes proposed in this pull request:

Part of https://github.com/cloud-gov/external-domain-broker/issues/412

- add ListCachePolicies and ListOriginRequestPolicies permissions to external-domain-broker user

## security considerations

None. These permissions are read-only and scoped specifically to the IAM user for the external-domain-broker user