### PR TITLE
Add new concourse azs to sec group peering

### DIFF
--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -230,14 +230,17 @@ module "stack" {
   cidr_blocks                 = var.cidr_blocks
 
   target_vpc_id          = data.terraform_remote_state.target_vpc.outputs.vpc_id
-  target_vpc_cidr        = data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr
+  target_vpc_cidr        = data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr_az1
   target_az1_route_table = data.terraform_remote_state.target_vpc.outputs.private_route_table_az1
   target_az2_route_table = data.terraform_remote_state.target_vpc.outputs.private_route_table_az2
 
   target_concourse_security_group_cidrs = [
-    data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr,
-    data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr,
+    data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr_az1,
+    data.terraform_remote_state.target_vpc.outputs.production_concourse_subnet_cidr_az1,
+    data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr_az1,
+    data.terraform_remote_state.target_vpc.outputs.staging_concourse_subnet_cidr_az1,
     data.terraform_remote_state.target_vpc.outputs.private_subnet_az1_cidr,
+    data.terraform_remote_state.target_vpc.outputs.private_subnet_az2_cidr,
   ]
 
   parent_vpc_id              = data.terraform_remote_state.parent_vpc.outputs.vpc_id

--- a/terraform/stacks/tooling/stack.tf
+++ b/terraform/stacks/tooling/stack.tf
@@ -112,7 +112,7 @@ module "stack" {
   rds_allow_major_version_upgrade        = var.rds_allow_major_version_upgrade
   rds_apply_immediately                  = var.rds_apply_immediately
   bosh_default_ssh_public_key            = var.bosh_default_ssh_public_key
-  target_concourse_security_group_cidrs  = [cidrsubnet(var.vpc_cidr, 8, 30), cidrsubnet(var.vpc_cidr, 8, 31), cidrsubnet(var.vpc_cidr, 8, 38), cidrsubnet(var.vpc_cidr, 8, 1)]
+  target_concourse_security_group_cidrs  = [cidrsubnet(var.vpc_cidr, 8, 30), cidrsubnet(var.vpc_cidr, 8, 60), cidrsubnet(var.vpc_cidr, 8, 31), cidrsubnet(var.vpc_cidr, 8, 61), cidrsubnet(var.vpc_cidr, 8, 38), cidrsubnet(var.vpc_cidr, 8, 1)]
   target_monitoring_security_group_cidrs = [cidrsubnet(var.vpc_cidr, 8, 32)]
   s3_gateway_policy_accounts             = var.s3_gateway_policy_accounts
   credhub_rds_db_engine_version          = var.rds_db_engine_version_bosh_credhub


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add the new Concourse production and staging availability zones to the list of subnets allowed after each child environment is peered with tooling
- Part of https://github.com/cloud-gov/private/issues/2469
-

## security considerations
Expands the list of allowed security groups across peering to include a second az for concourse
