### PR TITLE
add WAF permissions for external domain broker

### DIFF
--- a/terraform/modules/cloudfoundry/outputs.tf
+++ b/terraform/modules/cloudfoundry/outputs.tf
@@ -156,3 +156,7 @@ output "tcp_lb_listener_ports" {
 output "tcp_lb_security_groups" {
   value = aws_security_group.nlb_traffic.*
 }
+
+output "waf_log_group_arn" {
+  value = aws_cloudwatch_log_group.cf_uaa_waf_core_cloudwatch_log_group.arn
+}

--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -80,6 +80,59 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       values   = [aws_iam_user.iam_user.arn]
     }
   }
+
+  # this permission is required for wafv2:PutLoggingConfiguration
+  # see https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html#awswafv2-actions-as-permissions
+  statement {
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+  statement {
+    actions = [
+      "wafv2:CreateWebACL",
+      "wafv2:TagResource",
+      "wafv2:UntagResource",
+      "wafv2:GetWebACL"
+    ]
+    resources = [
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+  }
+
+  statement {
+    actions = [
+      "wafv2:PutLoggingConfiguration",
+      "wafv2:DeleteLoggingConfiguration"
+    ]
+    resources = [
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "wafv2:LogDestinationResource"
+      values   = [var.waf_log_group_arn]
+    }
+  }
 }
 
 resource "aws_iam_user" "iam_user" {

--- a/terraform/modules/external_domain_broker_govcloud/variables.tf
+++ b/terraform/modules/external_domain_broker_govcloud/variables.tf
@@ -13,3 +13,8 @@ variable "aws_region" {
   type        = string
   description = "AWS region where the resources are deployed"
 }
+
+variable "waf_log_group_arn" {
+  type        = string
+  description = "ARN of CloudWatch log group for WAF logs"
+}

--- a/terraform/stacks/main/stack.tf
+++ b/terraform/stacks/main/stack.tf
@@ -423,6 +423,7 @@ module "external_domain_broker_govcloud" {
   stack_description = var.stack_description
   aws_region        = data.aws_region.current.region
   aws_partition     = data.aws_partition.current.partition
+  waf_log_group_arn = module.cf.waf_log_group_arn
 }
 
 module "dns_logging" {


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/external-domain-broker/pull/435

- Add permissions for external domain broker to provision WAF web ACLs

## security considerations

These permissions are the least privilege necessary for the broker and they are scoped to only be invocable by the specified IAM user
