### PR TITLE
fix resources for external domain broker IAM policy

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -159,7 +159,7 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       "wafv2:GetWebACL"
     ]
     resources = [
-      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:regional/webacl/cg-external-domains-*",
     ]
     condition {
       test     = "StringEquals"
@@ -179,7 +179,7 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
       "wafv2:DeleteLoggingConfiguration"
     ]
     resources = [
-      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:global/webacl/cg-external-domains-*",
+      "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:regional/webacl/cg-external-domains-*",
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix resources for external domain broker IAM policy to target regional WAF resources


## security considerations

No change in the actual permissions provisioned, just correcting the incorrect references to resources in the IAM policy
