### PR TITLE
add AssociateWebACL permission for external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -156,7 +156,8 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
     actions = [
       "wafv2:TagResource",
       "wafv2:UntagResource",
-      "wafv2:GetWebACL"
+      "wafv2:GetWebACL",
+      "wafv2:AssociateWebACL"
     ]
     resources = [
       "arn:${var.aws_partition}:wafv2:${var.aws_region}:${var.account_id}:regional/webacl/cg-external-domains-*",


### PR DESCRIPTION
## Changes proposed in this pull request:

- add AssociateWebACL permission for external domain broker

## security considerations

The new permission is limited only to the specified IAM user and only for a certain set of IPs
