### PR TITLE
Hard code max_conns pending research

### DIFF
--- a/terraform/modules/rds_stig/parameter_group.tf
+++ b/terraform/modules/rds_stig/parameter_group.tf
@@ -88,8 +88,11 @@ resource "aws_db_parameter_group" "parameter_group_mysql" {
   # max_connections is DBInstanceClassMemory/12582880
   # so we use a value 5% higher for the denominator
   # to leave some % of connections free
+  # FixMe: Using string results in :
+  #  "api error InvalidParameterValue: invalid parameter value: DBInstanceClassMemory/13212024"
+  # So using value for an XLarge 16GiB Instance
   parameter {
     name  = "max_user_connections"
-    value = "DBInstanceClassMemory/13212024"
+    value = 1210
   }
 }


### PR DESCRIPTION
Using a dynamic setting works in the Console, but not in TF (AWS API error: modifying RDS DB Parameter Group (development-mysqlstig): operation error RDS: ModifyDBParameterGroup, https response error StatusCode: 400, RequestID: d971c730-896c-4f33-b3ce-004172a99df5, api error InvalidParameterValue: invalid parameter value: DBInstanceClassMemory/13212024")

We'll see if there's a workaround in TF or w/ AWS Support, but meanwhile let's unblock the pipeline.

## Changes proposed in this pull request:
-
-
-

## security considerations
Safe. Uses a STIG-recommended setting.
