### PR TITLE
Use max_user_connections that's below max_connections

### DIFF
--- a/terraform/modules/rds_stig/parameter_group.tf
+++ b/terraform/modules/rds_stig/parameter_group.tf
@@ -89,8 +89,8 @@ resource "aws_db_parameter_group" "parameter_group_mysql" {
   #  "api error InvalidParameterValue: invalid parameter value: DBInstanceClassMemory/13212024"
   # Using value below lowest possible than max_connections of 85 
   parameter {
-    name  = "max_user_connections"
-    value = 75
+    name         = "max_user_connections"
+    value        = 75
     apply_method = "pending-reboot"
   }
 }


### PR DESCRIPTION
Our smallest micro instances are 1GiB, so max_connections is (1 * 1024 * 1024 * 1024 )/12582880 = 85

Using 75  to leave 10 free.

## Changes proposed in this pull request:
-
-
-

## security considerations
Safe.
