### PR TITLE
Send inquiries email to Zendeksk

### DIFF
--- a/terraform/stacks/dns/validators.tf
+++ b/terraform/stacks/dns/validators.tf
@@ -29,11 +29,11 @@ resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "support.cloud.gov."
   type    = "CNAME"
-  ttl     = 60
+  ttl     = 300
   records = ["cloud-gov-new.zendesk.com."]
 }
 
-resource "aws_route53_record" "cloud_gov_zendesk_support_cname" {
+resource "aws_route53_record" "cloud_gov_inquiries_zendesk_support_cname" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "inquiries.cloud.gov."
   type    = "CNAME"
@@ -45,7 +45,7 @@ resource "aws_route53_record" "cloud_gov_pages_zendesk_support_cname" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "pages-support.cloud.gov."
   type    = "CNAME"
-  ttl     = 60
+  ttl     = 300
   records = ["cloud-gov-pages.zendesk.com."]
 }
 
@@ -53,7 +53,7 @@ resource "aws_route53_record" "cloud_gov_workshop_zendesk_support_cname" {
   zone_id = aws_route53_zone.cloud_gov_zone.zone_id
   name    = "workshop-support.cloud.gov."
   type    = "CNAME"
-  ttl     = 60
+  ttl     = 300
   records = ["cloud-gov-workshop.zendesk.com."]
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Add cname for `inquiries.cloud.gov` to enable zendesk for inquiries@cloud.gov
- Bump TTL for stable zendesk entries to 300 seconds

## Additional steps

Google Groups:
- Main support address:
  - inquiries@cloud.gov - already exists as a google group
- For correspondence with internal GSA customers to get around ZenDesk email limitations.
  - cloud-gov-inquires@gsa.gov - already exists 

We will need to 
- Add the ZenDesk email address as group member: `inquiries@cloud-gov-inquiries.zendesk.com`
- Add a CNAME (this issue)
- Test email deliveyr
- Add inquiries team members (Do we have the seats for EGK and Nicki?)
-

## security considerations
Safe. Reroutes email to an already authorized provider
