### PR TITLE
add permission to external domain broker

### DIFF
--- a/terraform/modules/external_domain_broker_govcloud/iam.tf
+++ b/terraform/modules/external_domain_broker_govcloud/iam.tf
@@ -176,6 +176,25 @@ data "aws_iam_policy_document" "external_domain_broker_policy" {
 
   statement {
     actions = [
+      "wafv2:ListWebACLs"
+    ]
+    resources = [
+      "*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalArn"
+      values   = [aws_iam_user.iam_user.arn]
+    }
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = var.environment_nat_egress_ips
+    }
+  }
+
+  statement {
+    actions = [
       "wafv2:PutLoggingConfiguration",
       "wafv2:DeleteLoggingConfiguration"
     ]


### PR DESCRIPTION
## Changes proposed in this pull request:

- add permission to external domain broker

## security considerations

This permission is read-only and:

- Restricted to a specific IAM user
- Restricted to a specific set of IPs

The permission does use `*` as its resource constraint, but that is required by IAM: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awswafv2.html
