### PR TITLE
Metric lambda timeout is too low

### DIFF
--- a/terraform/modules/metrics_s3_ingestor/lambda.tf
+++ b/terraform/modules/metrics_s3_ingestor/lambda.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "transform" {
 }
 
 data "http" "lambda_python" {
-  url = "https://raw.githubusercontent.com/cloud-gov/aws_metrics_opensearch_preprocessor/refs/tags/v0.0.1/lambda_functions/transform_lambda.py"
+  url = "https://raw.githubusercontent.com/cloud-gov/aws_metrics_opensearch_preprocessor/refs/tags/v0.0.2/lambda_functions/transform_lambda.py"
 }
 
 data "archive_file" "lambda_zip" {


### PR DESCRIPTION
## Changes proposed in this pull request:
- setting timeout higher to 1 minute
-
-

## security considerations
None
