### PR TITLE
remove lifecycle policy

### DIFF
--- a/terraform/stacks/ecr/stack.tf
+++ b/terraform/stacks/ecr/stack.tf
@@ -49,18 +49,6 @@ resource "aws_ecr_lifecycle_policy" "ecr_repository_lifecycle_policy" {
             "action": {
                 "type": "expire"
             }
-        },
-        {
-            "rulePriority": 2,
-            "description": "Only keep the two latest images",
-            "selection": {
-                "tagStatus": "any",
-                "countType": "imageCountMoreThan",
-                "countNumber": 2
-            },
-            "action": {
-                "type": "expire"
-            }
         }
     ]
   }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removes the lifecycle policy for only keeping the two latest images
- We will reevaluate and create a new policy to account for staging and prod images

## security considerations
Removing this lifecycle policy won't have any major security impacts